### PR TITLE
enclose marshaller header

### DIFF
--- a/src/cycle_timer.c
+++ b/src/cycle_timer.c
@@ -5,6 +5,7 @@
  * SECTION:cycle_timer
  * @Title: HinokoCycleTimer
  * @Short_description: A boxed object to represent data for cycle timer.
+ * @include: cycle_timer.h
  *
  * A #HinokoCycleTimer is an boxed object to represent the value of cycle
  * timer and timestamp referring to clock_id.

--- a/src/fw_iso_ctx.c
+++ b/src/fw_iso_ctx.c
@@ -14,6 +14,7 @@
  * SECTION:fw_iso_ctx
  * @Title: HinokoFwIsoCtx
  * @Short_description: An abstract object to maintain isochronous context.
+ * @include: fw_iso_ctx.h
  *
  * A #HinokoFwIsoCtx is an abstract object to maintain isochronous context by
  * UAPI of Linux FireWire subsystem. All of operations utilize ioctl(2) with

--- a/src/fw_iso_resource.c
+++ b/src/fw_iso_resource.c
@@ -7,6 +7,7 @@
 #include <sys/ioctl.h>
 
 #include "internal.h"
+#include "hinoko_sigs_marshal.h"
 
 /**
  * SECTION:fw_iso_resource

--- a/src/fw_iso_resource.c
+++ b/src/fw_iso_resource.c
@@ -14,6 +14,7 @@
  * @Title: HinokoFwIsoResource
  * @Short_description: An object to initiate requests and listen events of
  *		       isochronous resource allocation/deallocation.
+ * @include: fw_iso_resource.h
  *
  * A #HinokoFwIsoResource is an object to initiate requests and listen events
  * of isochronous resource allocation/deallocation by file descriptor owned

--- a/src/fw_iso_resource.h
+++ b/src/fw_iso_resource.h
@@ -5,7 +5,6 @@
 #include <glib.h>
 #include <glib-object.h>
 
-#include <hinoko_sigs_marshal.h>
 #include <hinoko_enums.h>
 
 G_BEGIN_DECLS

--- a/src/fw_iso_resource_auto.c
+++ b/src/fw_iso_resource_auto.c
@@ -9,6 +9,7 @@
  * SECTION:fw_iso_resource_auto
  * @Title: HinokoFwIsoResourceAuto
  * @Short_description: An object to maintain allocated isochronous resource.
+ * @include: fw_iso_resource_auto.h
  *
  * A #HinokoFwIsoResourceAuto is an object to maintain isochronous resource
  * during the lifetime of the object. The allocated isochronous resource is

--- a/src/fw_iso_rx_multiple.c
+++ b/src/fw_iso_rx_multiple.c
@@ -9,6 +9,7 @@
  * @Title: HinokoFwIsoRxMultiple
  * @Short_description: An object to receive isochronous packet for several
  *		       channels.
+ * @include: fw_iso_rx_multiple.h
  *
  * A #HinokoFwIsoRxMultiple receives isochronous packets for several channels by
  * IR context for buffer-fill mode in 1394 OHCI.

--- a/src/fw_iso_rx_multiple.h
+++ b/src/fw_iso_rx_multiple.h
@@ -7,7 +7,6 @@
 
 #include <fw_iso_ctx.h>
 #include <hinoko_enums.h>
-#include <hinoko_sigs_marshal.h>
 
 G_BEGIN_DECLS
 

--- a/src/fw_iso_rx_single.c
+++ b/src/fw_iso_rx_single.c
@@ -10,6 +10,7 @@
  * @Title: HinokoFwIsoRxSingle
  * @Short_description: An object to receive isochronous packet for single
  *		       channel.
+ * @include: fw_iso_rx_single.h
  *
  * A #HinokoFwIsoRxSingle receives isochronous packets for single channel by IR
  * context for packet-per-buffer mode in 1394 OHCI. The content of packet is

--- a/src/fw_iso_tx.c
+++ b/src/fw_iso_tx.c
@@ -10,6 +10,7 @@
  * @Title: HinokoFwIsoTx
  * @Short_description: An object to transmit isochronous packet for single
  *		       channel.
+ * @include: fw_iso_tx.h
  *
  * A #HinokoFwIsoTx transmits isochronous packets for single channel by IT
  * context in 1394 OHCI. The content of packet is split to two parts; context

--- a/src/fw_iso_tx.h
+++ b/src/fw_iso_tx.h
@@ -7,7 +7,6 @@
 
 #include <fw_iso_ctx.h>
 #include <hinoko_enums.h>
-#include <hinoko_sigs_marshal.h>
 
 G_BEGIN_DECLS
 


### PR DESCRIPTION
Auto-generated marshaller header file is not useless to applications. This patchset eliminates inclusion of the file from public header.
