### PR TITLE
fw_iso_ctx: control flow optimization for event handling

### DIFF
--- a/samples/iso-rx-multiple
+++ b/samples/iso-rx-multiple
@@ -50,6 +50,12 @@ class IsoRxMultiple(Hinoko.FwIsoRxMultiple):
             self.__timer.cancel()
             print(error)
 
+    @staticmethod
+    def __ohci1394_tstamp_to_isoc_cycle(tstamp):
+        sec = (tstamp & 0x0000e000) >> 13
+        cycle = tstamp & 0x00001fff
+        return (sec, cycle)
+
     def do_interrupted(self, count):
         for i in range(count):
             data = self.get_payload(i)
@@ -59,8 +65,7 @@ class IsoRxMultiple(Hinoko.FwIsoRxMultiple):
             frames = unpack('>{0}I'.format(len(data[4:-4]) // 4), data[4:-4])
 
             tstamp = unpack('<I', data[-4:])[0]
-            sec = (tstamp & 0x0000e000) >> 13
-            cycle = tstamp & 0x00001fff
+            sec, cycle = self.__ohci1394_tstamp_to_isoc_cycle(tstamp)
 
             print('{0:d},{1:d},{2:08x},{3[0]:08x},{3[1]:08x},{4}'.format(sec, cycle, iso_header, frames, i))
             for i, frame in enumerate(frames):

--- a/samples/iso-rx-single
+++ b/samples/iso-rx-single
@@ -63,13 +63,18 @@ class IsoRxSingle(Hinoko.FwIsoRxSingle):
             self.__timer.cancel()
             print(error)
 
+    @staticmethod
+    def __ohci1394_tstamp_to_isoc_cycle(tstamp):
+        sec = (tstamp & 0x0000e000) >> 13
+        cycle = tstamp & 0x00001fff
+        return (sec, cycle)
+
     def do_interrupted(self, sec, cycle, header, header_length, count):
         headers = unpack('>{0}I'.format(header_length // 4), header)
         for i in range(count):
             iso_header, tstamp = headers[i * 2:(i + 1) * 2]
 
-            sec = (tstamp & 0x0000e000) >> 13
-            cycle = tstamp & 0x00001fff
+            sec, cycle = self.__ohci1394_tstamp_to_isoc_cycle(tstamp)
 
             data = self.get_payload(i)
             frames = unpack('>{0}I'.format(len(data) // 4), data)

--- a/samples/iso-rx-single
+++ b/samples/iso-rx-single
@@ -34,24 +34,26 @@ class IsoRxSingle(Hinoko.FwIsoRxSingle):
                Hinoko.FwIsoCtxMatchFlag.TAG2 | \
                Hinoko.FwIsoCtxMatchFlag.TAG3
 
+        # Start one half of second later. Scheduling is available with lower 2 bits of second field.
         cycle_timer = Hinoko.CycleTimer.new()
         clock_id = 4    #CLOCK_MONOTONIC_RAW
         cycle_timer = self.get_cycle_timer(clock_id, cycle_timer)
         (sec, cycle, tick) = cycle_timer.get_cycle_timer()
+        sec, cycle = self.__increment_cycle(sec, cycle, 4000)
+        cycle_match = (sec & 0x3, cycle)
 
-        # Start one half of second later.
-        cycle += 4000
+        self.__timer.start()
+        self.start(cycle_match, 0, tags, 80)
+
+    @staticmethod
+    def __increment_cycle(sec, cycle, addend):
+        cycle += addend
         if cycle >= 8000:
             cycle %= 8000
             sec += 1
             if sec >= 128:
                 sec %= 128
-
-        # Scheduling is available with lower 2 bits of second field.
-        cycle_match = (sec & 0x3, cycle)
-
-        self.__timer.start()
-        self.start(cycle_match, 0, tags, 80)
+        return (sec, cycle)
 
     def finish(self):
         self.__src.destroy()

--- a/samples/iso-rx-single
+++ b/samples/iso-rx-single
@@ -20,6 +20,15 @@ class IsoRxSingle(Hinoko.FwIsoRxSingle):
         self.unmap_buffer()
         self.release()
 
+    def queue_packet(self):
+        schedule_interrupt = False
+
+        self.accumulated_packet_count += 1
+        if self.accumulated_packet_count % self.packets_per_interrupt == 0:
+            schedule_interrupt = True
+
+        self.register_packet(schedule_interrupt)
+
     def begin(self, dispatcher, duration):
         self.__src = self.create_source()
         self.__src.attach(dispatcher.get_context())
@@ -42,8 +51,15 @@ class IsoRxSingle(Hinoko.FwIsoRxSingle):
         sec, cycle = self.__increment_cycle(sec, cycle, 4000)
         cycle_match = (sec & 0x3, cycle)
 
+        self.accumulated_packet_count = 0
+        self.packets_per_interrupt = 80
+
+        # Schedule for some isochronous cycles.
+        for i in range(self.packets_per_interrupt * 2):
+            self.queue_packet()
+
         self.__timer.start()
-        self.start(cycle_match, 0, tags, 80)
+        self.start(cycle_match, 0, tags)
 
     @staticmethod
     def __increment_cycle(sec, cycle, addend):
@@ -84,6 +100,8 @@ class IsoRxSingle(Hinoko.FwIsoRxSingle):
             print('{0:d},{1:d},{2:08x},{3}'.format(sec, cycle, iso_header, i))
             for i, frame in enumerate(frames):
                 print('    {0:2d}: {1:08x}'.format(i, frame))
+
+            self.queue_packet()
 
 # 2 CIP headers + 3 quadlet per data block * 8 data block
 channel = 1

--- a/samples/iso-tx
+++ b/samples/iso-tx
@@ -11,11 +11,11 @@ from gi.repository import Hinoko
 
 class IsoTx(Hinoko.FwIsoTx):
     def new(self, path, channel, maximum_bytes_per_payload):
-        # Use 8 byte header.
-        header_size = 8
-        self.payload = [i for i in range(maximum_bytes_per_payload)]
+        # Use 8 byte header for CIP header.
+        cip_header_size = 8
+        self.cip_payload = [i for i in range(maximum_bytes_per_payload)]
 
-        self.allocate(path, Hinoko.FwScode.S400, channel, header_size)
+        self.allocate(path, Hinoko.FwScode.S400, channel, cip_header_size)
 
         payloads_per_buffer = 32
         self.map_buffer(maximum_bytes_per_payload, payloads_per_buffer)
@@ -92,13 +92,16 @@ class IsoTx(Hinoko.FwIsoTx):
     def do_interrupted(self, sec, cycle, header, header_length, count):
         tstamps = unpack('>{0}I'.format(header_length // 4), header)
         for i in range(count):
+            # Schedule packet at the completed isochronous cycle plus packets per buffer. The header
+            # of packet has data for the completed isochronous cycle.
             sec, cycle = self.__cycles
-            header = pack('>2I', sec, cycle)
-            self.register_packet(self.tag, self.sy, header, self.payload)
+            cip_header = pack('>2I', sec, cycle)
+            self.register_packet(self.tag, self.sy, cip_header, self.cip_payload)
             self.__increment_cycle(1)
 
+            # Print the data of packet already sent.
             sec, cycle = self.__ohci1394_tstamp_to_isoc_cycle(tstamps[i])
-            iso_header = (len(self.payload) << 16) | \
+            iso_header = (len(self.cip_payload) << 16) | \
                          (self.tag << 14) | \
                          (self.channel << 8) | \
                          (0xa << 4) | \

--- a/samples/iso-tx
+++ b/samples/iso-tx
@@ -10,23 +10,23 @@ gi.require_version('Hinoko', '0.0')
 from gi.repository import Hinoko
 
 class IsoTx(Hinoko.FwIsoTx):
-    def new(self, path, channel, maximum_bytes_per_payload):
+    def new(self, path, channel, maximum_bytes_per_payload, packets_per_buffer):
         # Use 8 byte header for CIP header.
         cip_header_size = 8
         self.cip_payload = [i for i in range(maximum_bytes_per_payload)]
 
         self.allocate(path, Hinoko.FwScode.S400, channel, cip_header_size)
 
-        self.packets_per_buffer = 32
-        self.map_buffer(maximum_bytes_per_payload, self.packets_per_buffer)
+        self.map_buffer(maximum_bytes_per_payload, packets_per_buffer)
 
         self.channel = channel
+        self.packets_per_buffer = packets_per_buffer
 
     def destroy(self):
         self.unmap_buffer()
         self.release()
 
-    def begin(self, dispatcher, duration):
+    def begin(self, dispatcher, packets_per_interrupt, duration):
         self.__src = self.create_source()
         self.__src.attach(dispatcher.get_context())
         self.__dispatcher = dispatcher
@@ -46,11 +46,8 @@ class IsoTx(Hinoko.FwIsoTx):
         sec, cycle = self.__increment_cycle(sec, cycle, 800)
         cycle_match = (sec & 0x3, cycle)
 
-        # The packets for buffer are queued with skip flag.
-        packets_per_irq = 4
-
         self.__timer.start()
-        self.start(cycle_match, packets_per_irq)
+        self.start(cycle_match, packets_per_interrupt)
 
     @staticmethod
     def __increment_cycle(sec, cycle, addend):
@@ -99,13 +96,16 @@ class IsoTx(Hinoko.FwIsoTx):
 
 channel = 30
 maximum_bytes_per_payload = 32
+packets_per_buffer = 32
+packets_per_interrupt = 4
+duration = 4
 
 ctx = IsoTx()
-ctx.new('/dev/fw0', channel, maximum_bytes_per_payload)
+ctx.new('/dev/fw0', channel, maximum_bytes_per_payload, packets_per_buffer)
 
 dispatcher = GLib.MainLoop.new(None, False)
 
-ctx.begin(dispatcher, 4)
+ctx.begin(dispatcher, packets_per_interrupt, duration)
 dispatcher.run()
 ctx.finish()
 ctx.destroy()

--- a/samples/iso-tx
+++ b/samples/iso-tx
@@ -26,6 +26,14 @@ class IsoTx(Hinoko.FwIsoTx):
         self.unmap_buffer()
         self.release()
 
+    def queue_packet(self, cip_header, cip_payload):
+        self.accumulated_packet_count += 1
+        if self.accumulated_packet_count % self.packets_per_interrupt == 0:
+            schedule_interrupt = True
+        else:
+            schedule_interrupt = False
+        self.register_packet(self.tag, self.sy, cip_header, cip_payload, schedule_interrupt)
+
     def begin(self, dispatcher, packets_per_interrupt, duration):
         self.__src = self.create_source()
         self.__src.attach(dispatcher.get_context())
@@ -46,8 +54,15 @@ class IsoTx(Hinoko.FwIsoTx):
         sec, cycle = self.__increment_cycle(sec, cycle, 800)
         cycle_match = (sec & 0x3, cycle)
 
+        self.accumulated_packet_count = 0
+        self.packets_per_interrupt = packets_per_interrupt
+
+        # Schedule some isochronous cycles to skip.
+        for i in range(packets_per_interrupt * 2):
+            self.queue_packet(None, None)
+
         self.__timer.start()
-        self.start(cycle_match, packets_per_interrupt)
+        self.start(cycle_match)
 
     @staticmethod
     def __increment_cycle(sec, cycle, addend):
@@ -84,7 +99,7 @@ class IsoTx(Hinoko.FwIsoTx):
             # of packet has data for the completed isochronous cycle.
             next_sec, next_cycle = self.__increment_cycle(sec, cycle, self.packets_per_buffer)
             cip_header = pack('>2I', next_sec, next_cycle)
-            self.register_packet(self.tag, self.sy, cip_header, self.cip_payload)
+            self.queue_packet(cip_header, self.cip_payload)
 
             # Print the data of packet already sent.
             iso_header = (len(self.cip_payload) << 16) | \

--- a/samples/iso-tx
+++ b/samples/iso-tx
@@ -83,17 +83,21 @@ class IsoTx(Hinoko.FwIsoTx):
             self.__timer.cancel()
             print(error)
 
+    @staticmethod
+    def __ohci1394_tstamp_to_isoc_cycle(tstamp):
+        sec = (tstamp & 0x0000e000) >> 13
+        cycle = tstamp & 0x00001fff
+        return (sec, cycle)
+
     def do_interrupted(self, sec, cycle, header, header_length, count):
-        headers = unpack('>{0}I'.format(header_length // 4), header)
+        tstamps = unpack('>{0}I'.format(header_length // 4), header)
         for i in range(count):
             sec, cycle = self.__cycles
             header = pack('>2I', sec, cycle)
             self.register_packet(self.tag, self.sy, header, self.payload)
             self.__increment_cycle(1)
 
-            tstamp = headers[i]
-            sec = (tstamp & 0x0000e000) >> 13
-            cycle = tstamp & 0x00001fff
+            sec, cycle = self.__ohci1394_tstamp_to_isoc_cycle(tstamps[i])
             iso_header = (len(self.payload) << 16) | \
                          (self.tag << 14) | \
                          (self.channel << 8) | \

--- a/samples/iso-tx
+++ b/samples/iso-tx
@@ -17,8 +17,8 @@ class IsoTx(Hinoko.FwIsoTx):
 
         self.allocate(path, Hinoko.FwScode.S400, channel, cip_header_size)
 
-        payloads_per_buffer = 32
-        self.map_buffer(maximum_bytes_per_payload, payloads_per_buffer)
+        self.packets_per_buffer = 32
+        self.map_buffer(maximum_bytes_per_payload, self.packets_per_buffer)
 
         self.channel = channel
 
@@ -38,40 +38,29 @@ class IsoTx(Hinoko.FwIsoTx):
         self.tag = Hinoko.FwIsoCtxMatchFlag.TAG1
         self.sy = 0
 
+        # Start 100 msec later. Scheduling is available with lower 2 bits of second field.
         cycle_timer = Hinoko.CycleTimer.new()
         clock_id = 4    # CLOCK_MONOTONIC_RAW
         cycle_timer = self.get_cycle_timer(clock_id, cycle_timer)
         (sec, cycle, tick) = cycle_timer.get_cycle_timer()
-
-        # Start 100 msec later.
-        cycle += 800
-        if cycle >= 8000:
-            cycle %= 8000
-            sec += 1
-            if sec >= 128:
-                sec %= 128
-
-        # Scheduling is available with lower 2 bits of second field.
+        sec, cycle = self.__increment_cycle(sec, cycle, 800)
         cycle_match = (sec & 0x3, cycle)
 
         # The packets for buffer are queued with skip flag.
         packets_per_irq = 4
-        self.__cycles = [sec, cycle]
-        self.__increment_cycle(packets_per_irq * 2)
 
         self.__timer.start()
         self.start(cycle_match, packets_per_irq)
 
-    def __increment_cycle(self, addend):
-        sec, cycle = self.__cycles
+    @staticmethod
+    def __increment_cycle(sec, cycle, addend):
         cycle += addend
         if cycle >= 8000:
             cycle %= 8000
             sec += 1
             if sec >= 128:
                 sec %= 128
-        self.__cycles[0] = sec
-        self.__cycles[1] = cycle
+        return (sec, cycle)
 
     def finish(self):
         self.__src.destroy()
@@ -92,15 +81,15 @@ class IsoTx(Hinoko.FwIsoTx):
     def do_interrupted(self, sec, cycle, header, header_length, count):
         tstamps = unpack('>{0}I'.format(header_length // 4), header)
         for i in range(count):
+            sec, cycle = self.__ohci1394_tstamp_to_isoc_cycle(tstamps[i])
+
             # Schedule packet at the completed isochronous cycle plus packets per buffer. The header
             # of packet has data for the completed isochronous cycle.
-            sec, cycle = self.__cycles
-            cip_header = pack('>2I', sec, cycle)
+            next_sec, next_cycle = self.__increment_cycle(sec, cycle, self.packets_per_buffer)
+            cip_header = pack('>2I', next_sec, next_cycle)
             self.register_packet(self.tag, self.sy, cip_header, self.cip_payload)
-            self.__increment_cycle(1)
 
             # Print the data of packet already sent.
-            sec, cycle = self.__ohci1394_tstamp_to_isoc_cycle(tstamps[i])
             iso_header = (len(self.cip_payload) << 16) | \
                          (self.tag << 14) | \
                          (self.channel << 8) | \

--- a/src/fw_iso_ctx.c
+++ b/src/fw_iso_ctx.c
@@ -479,6 +479,7 @@ void hinoko_fw_iso_ctx_set_rx_channels(HinokoFwIsoCtx *self,
  * 	    header for IT context, nothing for IR context.
  * @header_length: The number of bytes for @header.
  * @payload_length: The number of bytes for payload of isochronous context.
+ * @schedule_interrupt: schedule hardware interrupt at isochronous cycle for the chunk.
  * @exception: A #GError.
  *
  * Register data on buffer for payload of isochronous context.
@@ -486,7 +487,8 @@ void hinoko_fw_iso_ctx_set_rx_channels(HinokoFwIsoCtx *self,
 void hinoko_fw_iso_ctx_register_chunk(HinokoFwIsoCtx *self, gboolean skip,
 				      HinokoFwIsoCtxMatchFlag tags, guint sy,
 				      const guint8 *header, guint header_length,
-				      guint payload_length, GError **exception)
+				      guint payload_length, gboolean schedule_interrupt,
+				      GError **exception)
 {
 	HinokoFwIsoCtxPrivate *priv;
 	struct fw_cdev_iso_packet *datum;
@@ -556,6 +558,9 @@ void hinoko_fw_iso_ctx_register_chunk(HinokoFwIsoCtx *self, gboolean skip,
 
 	if (skip)
 		datum->control |= FW_CDEV_ISO_SKIP;
+
+	if (schedule_interrupt)
+		datum->control |= FW_CDEV_ISO_INTERRUPT;
 }
 
 static void fw_iso_ctx_queue_chunks(HinokoFwIsoCtx *self, GError **exception)

--- a/src/fw_iso_ctx.c
+++ b/src/fw_iso_ctx.c
@@ -983,3 +983,25 @@ void hinoko_fw_iso_ctx_read_frames(HinokoFwIsoCtx *self, guint offset,
 	else
 		*frame_size = bytes_per_buffer - offset;
 }
+
+/**
+ * hinoko_fw_iso_ctx_flush_completions:
+ * @self: A #HinokoFwIsoCtx.
+ * @exception: A #GError.
+ *
+ * Flush isochronous context until recent isochronous cycle. The call of function forces the
+ * context to queue any type of interrupt event for the recent isochronous cycle. Application can
+ * process the content of isochronous packet without waiting for actual hardware interrupt.
+ *
+ * Since: 0.6.
+ */
+void hinoko_fw_iso_ctx_flush_completions(HinokoFwIsoCtx *self, GError **exception)
+{
+	HinokoFwIsoCtxPrivate *priv;
+
+	g_return_if_fail(HINOKO_IS_FW_ISO_CTX(self));
+	priv = hinoko_fw_iso_ctx_get_instance_private(self);
+
+	if (ioctl(priv->fd, FW_CDEV_IOC_FLUSH_ISO) < 0)
+		generate_syscall_error(exception, errno, "ioctl(%s)", "FW_CDEV_IOC_FLUSH_ISO");
+}

--- a/src/fw_iso_ctx.h
+++ b/src/fw_iso_ctx.h
@@ -69,6 +69,8 @@ void hinoko_fw_iso_ctx_get_cycle_timer(HinokoFwIsoCtx *self, gint clock_id,
 void hinoko_fw_iso_ctx_create_source(HinokoFwIsoCtx *self, GSource **gsrc,
 				     GError **exception);
 
+void hinoko_fw_iso_ctx_flush_completions(HinokoFwIsoCtx *self, GError **exception);
+
 G_END_DECLS
 
 #endif

--- a/src/fw_iso_rx_multiple.c
+++ b/src/fw_iso_rx_multiple.c
@@ -293,7 +293,7 @@ static void fw_iso_rx_multiple_register_chunk(HinokoFwIsoRxMultiple *self,
 					      GError **exception)
 {
 	hinoko_fw_iso_ctx_register_chunk(HINOKO_FW_ISO_CTX(self), FALSE, 0, 0,
-					 NULL, 0, 0, exception);
+					 NULL, 0, 0, FALSE, exception);
 }
 
 /**

--- a/src/fw_iso_rx_multiple.c
+++ b/src/fw_iso_rx_multiple.c
@@ -346,8 +346,7 @@ void hinoko_fw_iso_rx_multiple_start(HinokoFwIsoRxMultiple *self,
 	}
 
 	priv->prev_offset = 0;
-	hinoko_fw_iso_ctx_start(HINOKO_FW_ISO_CTX(self), cycle_match, sync,
-				tags, chunks_per_irq, exception);
+	hinoko_fw_iso_ctx_start(HINOKO_FW_ISO_CTX(self), cycle_match, sync, tags, exception);
 }
 
 /**

--- a/src/fw_iso_rx_single.c
+++ b/src/fw_iso_rx_single.c
@@ -184,7 +184,7 @@ static void fw_iso_rx_single_register_chunk(HinokoFwIsoRxSingle *self,
 					    GError **exception)
 {
 	hinoko_fw_iso_ctx_register_chunk(HINOKO_FW_ISO_CTX(self), FALSE, 0, 0,
-					 NULL, 0, 0, exception);
+					 NULL, 0, 0, FALSE, exception);
 }
 
 /**

--- a/src/fw_iso_rx_single.c
+++ b/src/fw_iso_rx_single.c
@@ -244,8 +244,7 @@ void hinoko_fw_iso_rx_single_start(HinokoFwIsoRxSingle *self,
 			return;
 	}
 
-	hinoko_fw_iso_ctx_start(HINOKO_FW_ISO_CTX(self), cycle_match, sync,
-				tags, packets_per_irq, exception);
+	hinoko_fw_iso_ctx_start(HINOKO_FW_ISO_CTX(self), cycle_match, sync, tags, exception);
 }
 
 /**

--- a/src/fw_iso_rx_single.h
+++ b/src/fw_iso_rx_single.h
@@ -81,10 +81,11 @@ void hinoko_fw_iso_rx_single_map_buffer(HinokoFwIsoRxSingle *self,
 					GError **exception);
 void hinoko_fw_iso_rx_single_unmap_buffer(HinokoFwIsoRxSingle *self);
 
-void hinoko_fw_iso_rx_single_start(HinokoFwIsoRxSingle *self,
-				   const guint16 *cycle_match, guint32 sync,
-				   HinokoFwIsoCtxMatchFlag tags,
-				   guint packets_per_irq, GError **exception);
+void hinoko_fw_iso_rx_single_register_packet(HinokoFwIsoRxSingle *self, gboolean schedule_interrupt,
+					     GError **exception);
+
+void hinoko_fw_iso_rx_single_start(HinokoFwIsoRxSingle *self, const guint16 *cycle_match,
+				   guint32 sync, HinokoFwIsoCtxMatchFlag tags, GError **exception);
 void hinoko_fw_iso_rx_single_stop(HinokoFwIsoRxSingle *self);
 
 void hinoko_fw_iso_rx_single_get_payload(HinokoFwIsoRxSingle *self, guint index,

--- a/src/fw_iso_tx.c
+++ b/src/fw_iso_tx.c
@@ -181,7 +181,7 @@ static void fw_iso_tx_register_chunk(HinokoFwIsoTx *self,
 
 	hinoko_fw_iso_ctx_register_chunk(HINOKO_FW_ISO_CTX(self), skip, tags,
 					 sy, header, header_length,
-					 payload_length, exception);
+					 payload_length, FALSE, exception);
 }
 
 /**

--- a/src/fw_iso_tx.c
+++ b/src/fw_iso_tx.c
@@ -237,8 +237,7 @@ void hinoko_fw_iso_tx_start(HinokoFwIsoTx *self, const guint16 *cycle_match,
 			return;
 	}
 
-	hinoko_fw_iso_ctx_start(HINOKO_FW_ISO_CTX(self), cycle_match, 0, 0,
-				packets_per_irq, exception);
+	hinoko_fw_iso_ctx_start(HINOKO_FW_ISO_CTX(self), cycle_match, 0, 0, exception);
 
 }
 

--- a/src/fw_iso_tx.h
+++ b/src/fw_iso_tx.h
@@ -78,15 +78,14 @@ void hinoko_fw_iso_tx_map_buffer(HinokoFwIsoTx *self,
 				 GError **exception);
 void hinoko_fw_iso_tx_unmap_buffer(HinokoFwIsoTx *self);
 
-void hinoko_fw_iso_tx_start(HinokoFwIsoTx *self, const guint16 *cycle_match,
-			    guint packets_per_irq, GError **exception);
+void hinoko_fw_iso_tx_start(HinokoFwIsoTx *self, const guint16 *cycle_match, GError **exception);
 void hinoko_fw_iso_tx_stop(HinokoFwIsoTx *self);
 
 void hinoko_fw_iso_tx_register_packet(HinokoFwIsoTx *self,
 				HinokoFwIsoCtxMatchFlag tags, guint sy,
 				const guint8 *header, guint header_length,
 				const guint8 *payload, guint payload_length,
-				GError **exception);
+				gboolean schedule_interrupt, GError **exception);
 
 G_END_DECLS
 

--- a/src/hinoko.map
+++ b/src/hinoko.map
@@ -14,7 +14,6 @@ HINOKO_0_1_0 {
     "hinoko_fw_iso_rx_single_release";
     "hinoko_fw_iso_rx_single_map_buffer";
     "hinoko_fw_iso_rx_single_unmap_buffer";
-    "hinoko_fw_iso_rx_single_start";
     "hinoko_fw_iso_rx_single_stop";
     "hinoko_sigs_marshal_VOID__UINT_UINT_POINTER_UINT_UINT";
     "hinoko_fw_iso_rx_single_get_payload";
@@ -87,4 +86,7 @@ HINOKO_0_6_0 {
 
     "hinoko_fw_iso_tx_register_packet";
     "hinoko_fw_iso_tx_start";
+
+    "hinoko_fw_iso_rx_single_register_packet";
+    "hinoko_fw_iso_rx_single_start";
 } HINOKO_0_5_0;

--- a/src/hinoko.map
+++ b/src/hinoko.map
@@ -35,9 +35,7 @@ HINOKO_0_1_0 {
     "hinoko_fw_iso_tx_release";
     "hinoko_fw_iso_tx_map_buffer";
     "hinoko_fw_iso_tx_unmap_buffer";
-    "hinoko_fw_iso_tx_start";
     "hinoko_fw_iso_tx_stop";
-    "hinoko_fw_iso_tx_register_packet";
   local:
     *;
 };
@@ -86,4 +84,7 @@ HINOKO_0_5_0 {
 HINOKO_0_6_0 {
   global:
     "hinoko_fw_iso_ctx_flush_completions";
+
+    "hinoko_fw_iso_tx_register_packet";
+    "hinoko_fw_iso_tx_start";
 } HINOKO_0_5_0;

--- a/src/hinoko.map
+++ b/src/hinoko.map
@@ -82,3 +82,8 @@ HINOKO_0_5_0 {
     "hinoko_fw_iso_ctx_error_get_type";
     "hinoko_fw_iso_ctx_error_quark";
 } HINOKO_0_4_0;
+
+HINOKO_0_6_0 {
+  global:
+    "hinoko_fw_iso_ctx_flush_completions";
+} HINOKO_0_5_0;

--- a/src/internal.h
+++ b/src/internal.h
@@ -24,7 +24,8 @@ void hinoko_fw_iso_ctx_unmap_buffer(HinokoFwIsoCtx *self);
 void hinoko_fw_iso_ctx_register_chunk(HinokoFwIsoCtx *self, gboolean skip,
 				      HinokoFwIsoCtxMatchFlag tags, guint sy,
 				      const guint8 *header, guint header_length,
-				      guint payload_length, GError **exception);
+				      guint payload_length, gboolean schedule_interrupt,
+				      GError **exception);
 void hinoko_fw_iso_ctx_set_rx_channels(HinokoFwIsoCtx *self,
 				       guint64 *channel_flags,
 				       GError **exception);

--- a/src/internal.h
+++ b/src/internal.h
@@ -29,9 +29,8 @@ void hinoko_fw_iso_ctx_register_chunk(HinokoFwIsoCtx *self, gboolean skip,
 void hinoko_fw_iso_ctx_set_rx_channels(HinokoFwIsoCtx *self,
 				       guint64 *channel_flags,
 				       GError **exception);
-void hinoko_fw_iso_ctx_start(HinokoFwIsoCtx *self, const guint16 *cycle_match,
-			     guint32 sync, HinokoFwIsoCtxMatchFlag tags,
-			     guint chunks_per_irq, GError **exception);
+void hinoko_fw_iso_ctx_start(HinokoFwIsoCtx *self, const guint16 *cycle_match, guint32 sync,
+			     HinokoFwIsoCtxMatchFlag tags, GError **exception);
 void hinoko_fw_iso_ctx_stop(HinokoFwIsoCtx *self);
 void hinoko_fw_iso_ctx_read_frames(HinokoFwIsoCtx *self, guint offset,
 				   guint length, const guint8 **frames,

--- a/tests/fw-iso-ctx
+++ b/tests/fw-iso-ctx
@@ -18,6 +18,7 @@ props = (
 methods = (
     'get_cycle_timer',
     'create_source',
+    'flush_completions',
 )
 vmethods = (
     'do_stopped',

--- a/tests/fw-iso-rx-single
+++ b/tests/fw-iso-rx-single
@@ -17,6 +17,7 @@ methods = (
     'release',
     'map_buffer',
     'unmap_buffer',
+    'register_packet',
     'start',
     'stop',
     'get_payload',


### PR DESCRIPTION
The typical way for userspace applications to process content of
isochronous packet is to wait for interrupt event corresponding to
hardware interrupt scheduled in advance.

Current implementation of libhinoko schedules the interrupt transparently
from application, while for some cases it's convenient for the
application to schedule the interrupt voluntarily.

Furthermore, Linux FireWire subsystem allows userspace application to
flush isochronous context for packets completed at the recent isochronous
cycle. When flushing, interrupt event is immediately queued independent
of hardware interrupt. The application can process content of packet
by handling the event. It's also convenient.

This patchset adds support for the above control flow. At first,
Hinoko.FwIsoCtx.flush_completions() is newly available to flush
isochronous context. Then some APIs in below classes are changed so that
application can schedule hardware interrupt:

 * Hinoko.FwIsoTx
 * Hinoko.FwIsoRxSingle

Unfortunately, it's unavoidable to lose backward compatibility to v0.5 or
former, but the status of libhinoko is development and still unstable.