### PR TITLE
[PATCH 0/5] clean up meson configuration

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project('hinoko', 'c',
   version: '0.6.0',
   license: 'LGPL-2.1+',
-  meson_version: '>= 0.42.0',
+  meson_version: '>= 0.46.0',
 )
 
 version = meson.project_version().split('.')

--- a/src/meson.build
+++ b/src/meson.build
@@ -94,3 +94,6 @@ hinoko_gir = gnome.generate_gir(myself,
   header: 'hinoko.h',
   install: true,
 )
+
+# For test.
+builddir = meson.current_build_dir()

--- a/src/meson.build
+++ b/src/meson.build
@@ -94,8 +94,3 @@ hinoko_gir = gnome.generate_gir(myself,
   header: 'hinoko.h',
   install: true,
 )
-
-myself_dep = declare_dependency(
-  link_with: myself,
-  dependencies: dependencies,
-)

--- a/src/meson.build
+++ b/src/meson.build
@@ -76,7 +76,7 @@ pkg.generate(myself,
 )
 
 hinoko_gir = gnome.generate_gir(myself,
-  sources: sources + headers + marshallers + enums,
+  sources: enums + headers + sources,
   nsversion: '@0@.0'.format(major_version),
   namespace: 'Hinoko',
   symbol_prefix: 'hinoko_',

--- a/src/meson.build
+++ b/src/meson.build
@@ -28,6 +28,10 @@ headers = [
   'hinoko_enum_types.h'
 ]
 
+privates = [
+  'internal.h',
+]
+
 inc_dir = meson.project_name()
 
 # Generate marshallers for GObject signals.
@@ -52,7 +56,7 @@ mapfile = 'hinoko.map'
 vflag = '-Wl,--version-script,' + join_paths(meson.current_source_dir(), mapfile)
 
 myself = library(meson.project_name(),
-  sources: sources + headers + marshallers + enums,
+  sources: sources + headers + privates + marshallers + enums,
   version: meson.project_version(),
   soversion: major_version,
   install: true,

--- a/src/meson.build
+++ b/src/meson.build
@@ -70,16 +70,8 @@ install_headers(headers,
 )
 
 pkg = import('pkgconfig')
-pkg.generate(
-  version: meson.project_version(),
-  libraries: myself,
-  requires: [
-    'glib-2.0',
-    'gobject-2.0',
-  ],
-  name: meson.project_name(),
+pkg.generate(myself,
   description: 'A library to operate OHCI 1394 controller for isochronous stream',
-  filebase: meson.project_name(),
   subdirs: inc_dir,
 )
 

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -8,11 +8,9 @@ tests = [
   'fw-iso-resource-auto',
 ]
 
-objdir = join_paths(meson.build_root(), 'src')
-
 envs = environment()
-envs.append('LD_LIBRARY_PATH', objdir, separator : ':')
-envs.append('GI_TYPELIB_PATH', objdir, separator : ':')
+envs.append('LD_LIBRARY_PATH', builddir, separator : ':')
+envs.append('GI_TYPELIB_PATH', builddir, separator : ':')
 
 foreach test : tests
   name = test


### PR DESCRIPTION
This patchset cleans up current meson configuration.

```
Takashi Sakamoto (5):
  meson: obsolete unused variable for documentation
  meson: obsolete usage of deprecated meson.build_root()
  meson: evaluate private headers
  meson: simplify .pc generation for pkgconfig
  meson: suppress scan to marshaller codes for gir

 meson.build       |  2 +-
 src/meson.build   | 17 ++++++++---------
 tests/meson.build |  6 ++----
 3 files changed, 11 insertions(+), 14 deletions(-)
```