### PR TITLE
[PATCH] meson: delete subproject for gi-docgen

### DIFF
--- a/subprojects/gi-docgen.wrap
+++ b/subprojects/gi-docgen.wrap
@@ -1,5 +1,0 @@
-[wrap-git]
-directory=gi-docgen
-url=https://gitlab.gnome.org/GNOME/gi-docgen.git
-revision=main
-depth=1


### PR DESCRIPTION
Documentation of libhinoko is provided at:

 * https://takaswie.github.io/libhinoko-docs/

I think it not probable that users needs to generate documentation
in the environment in which gi-docgen is missing.

Signed-off-by: Takashi Sakamoto <o-takashi@sakamocchi.jp>