### PR TITLE
[PATCH 0/7] use utility macro to declare GObject-derived objects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -35,7 +35,7 @@ License
 Dependencies
 ============
 
-- Glib 2.34.0 or later
+- Glib 2.44.0 or later
 - GObject Introspection 1.32.1 or later
 - Linux kernel 3.4 or later
 

--- a/src/cycle_timer.h
+++ b/src/cycle_timer.h
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
-#ifndef __HINOKO_CYCLE_TIMER__H__
-#define __HINOKO_CYCLE_TIMER__H__
+#ifndef __HINOKO_CYCLE_TIMER_H__
+#define __HINOKO_CYCLE_TIMER_H__
 
 #include <hinoko.h>
 

--- a/src/fw_iso_ctx.c
+++ b/src/fw_iso_ctx.c
@@ -685,8 +685,8 @@ static void handle_irq_event(struct fw_cdev_event_iso_interrupt *ev,
 		HinokoFwIsoRxSingle *ctx = HINOKO_FW_ISO_RX_SINGLE((gpointer)ev->closure);
 
 		hinoko_fw_iso_rx_single_handle_event(ctx, ev, exception);
-	} else if (HINOKO_IS_FW_ISO_TX(ev->closure)) {
-		HinokoFwIsoTx *ctx = HINOKO_FW_ISO_TX(ev->closure);
+	} else if (HINOKO_IS_FW_ISO_TX((gpointer)ev->closure)) {
+		HinokoFwIsoTx *ctx = HINOKO_FW_ISO_TX((gpointer)ev->closure);
 
 		hinoko_fw_iso_tx_handle_event(ctx, ev, exception);
 	} else {

--- a/src/fw_iso_ctx.c
+++ b/src/fw_iso_ctx.c
@@ -702,9 +702,8 @@ static void handle_irq_event(struct fw_cdev_event_iso_interrupt *ev,
 static void handle_irq_mc_event(struct fw_cdev_event_iso_interrupt_mc *ev,
 				GError **exception)
 {
-	if (HINOKO_IS_FW_ISO_RX_MULTIPLE(ev->closure)) {
-		HinokoFwIsoRxMultiple *ctx =
-					HINOKO_FW_ISO_RX_MULTIPLE(ev->closure);
+	if (HINOKO_IS_FW_ISO_RX_MULTIPLE((gpointer)ev->closure)) {
+		HinokoFwIsoRxMultiple *ctx = HINOKO_FW_ISO_RX_MULTIPLE((gpointer)ev->closure);
 
 		hinoko_fw_iso_rx_multiple_handle_event(ctx, ev, exception);
 	} else {

--- a/src/fw_iso_ctx.c
+++ b/src/fw_iso_ctx.c
@@ -20,7 +20,7 @@
  * subsystem specific request commands. This object is designed for internal
  * use, therefore a few method and properties are available for applications.
  */
-struct _HinokoFwIsoCtxPrivate {
+typedef struct {
 	int fd;
 	guint handle;
 
@@ -38,9 +38,8 @@ struct _HinokoFwIsoCtxPrivate {
 
 	guint curr_offset;
 	gboolean running;
-};
-G_DEFINE_ABSTRACT_TYPE_WITH_PRIVATE(HinokoFwIsoCtx, hinoko_fw_iso_ctx,
-				    G_TYPE_OBJECT)
+} HinokoFwIsoCtxPrivate;
+G_DEFINE_ABSTRACT_TYPE_WITH_PRIVATE(HinokoFwIsoCtx, hinoko_fw_iso_ctx, G_TYPE_OBJECT)
 
 /**
  * hinoko_fw_iso_ctx_error_quark:
@@ -697,7 +696,7 @@ static void handle_irq_event(struct fw_cdev_event_iso_interrupt *ev,
 	if (*exception != NULL)
 		return;
 
-	fw_iso_ctx_queue_chunks(HINOKO_FW_ISO_CTX(ev->closure), exception);
+	fw_iso_ctx_queue_chunks(HINOKO_FW_ISO_CTX((gpointer)ev->closure), exception);
 }
 
 static void handle_irq_mc_event(struct fw_cdev_event_iso_interrupt_mc *ev,
@@ -715,7 +714,7 @@ static void handle_irq_mc_event(struct fw_cdev_event_iso_interrupt_mc *ev,
 	if (*exception != NULL)
 		return;
 
-	fw_iso_ctx_queue_chunks(HINOKO_FW_ISO_CTX(ev->closure), exception);
+	fw_iso_ctx_queue_chunks(HINOKO_FW_ISO_CTX((gpointer)ev->closure), exception);
 }
 
 static gboolean dispatch_src(GSource *gsrc, GSourceFunc cb, gpointer user_data)

--- a/src/fw_iso_ctx.c
+++ b/src/fw_iso_ctx.c
@@ -681,8 +681,8 @@ static gboolean check_src(GSource *gsrc)
 static void handle_irq_event(struct fw_cdev_event_iso_interrupt *ev,
 			     GError **exception)
 {
-	if (HINOKO_IS_FW_ISO_RX_SINGLE(ev->closure)) {
-		HinokoFwIsoRxSingle *ctx = HINOKO_FW_ISO_RX_SINGLE(ev->closure);
+	if (HINOKO_IS_FW_ISO_RX_SINGLE((gpointer)ev->closure)) {
+		HinokoFwIsoRxSingle *ctx = HINOKO_FW_ISO_RX_SINGLE((gpointer)ev->closure);
 
 		hinoko_fw_iso_rx_single_handle_event(ctx, ev, exception);
 	} else if (HINOKO_IS_FW_ISO_TX(ev->closure)) {

--- a/src/fw_iso_ctx.h
+++ b/src/fw_iso_ctx.h
@@ -6,41 +6,13 @@
 
 G_BEGIN_DECLS
 
-#define HINOKO_TYPE_FW_ISO_CTX	(hinoko_fw_iso_ctx_get_type())
+#define HINOKO_TYPE_FW_ISO_CTX		(hinoko_fw_iso_ctx_get_type())
 
-#define HINOKO_FW_ISO_CTX(obj)					\
-	(G_TYPE_CHECK_INSTANCE_CAST((obj),			\
-				    HINOKO_TYPE_FW_ISO_CTX,	\
-				    HinokoFwIsoCtx))
-#define HINOKO_IS_FW_ISO_CTX(obj)				\
-	(G_TYPE_CHECK_INSTANCE_TYPE((obj),			\
-				    HINOKO_TYPE_FW_ISO_CTX))
-
-#define HINOKO_FW_ISO_CTX_CLASS(klass)				\
-	(G_TYPE_CHECK_CLASS_CAST((klass),			\
-				 HINOKO_TYPE_FW_ISO_CTX,	\
-				 HinokoFwIsoCtxClass))
-#define HINOKO_IS_FW_ISO_CTX_CLASS(klass)			\
-	(G_TYPE_CHECK_CLASS_TYPE((klass),			\
-				 HINOKO_TYPE_FW_ISO_CTX))
-#define HINOKO_FW_ISO_CTX_GET_CLASS(obj)			\
-	(G_TYPE_INSTANCE_GET_CLASS((obj),			\
-				   HINOKO_TYPE_FW_ISO_CTX,	\
-				   HinokoFwIsoCtxClass))
+G_DECLARE_DERIVABLE_TYPE(HinokoFwIsoCtx, hinoko_fw_iso_ctx, HINOKO, FW_ISO_CTX, GObject);
 
 #define HINOKO_FW_ISO_CTX_ERROR		hinoko_fw_iso_ctx_error_quark()
 
 GQuark hinoko_fw_iso_ctx_error_quark();
-
-typedef struct _HinokoFwIsoCtx		HinokoFwIsoCtx;
-typedef struct _HinokoFwIsoCtxClass	HinokoFwIsoCtxClass;
-typedef struct _HinokoFwIsoCtxPrivate	HinokoFwIsoCtxPrivate;
-
-struct _HinokoFwIsoCtx {
-	GObject parent_instance;
-
-	HinokoFwIsoCtxPrivate *priv;
-};
 
 struct _HinokoFwIsoCtxClass {
 	GObjectClass parent_class;
@@ -56,7 +28,6 @@ struct _HinokoFwIsoCtxClass {
 	void (*stopped)(HinokoFwIsoCtx *self, GError *error);
 };
 
-GType hinoko_fw_iso_ctx_get_type(void) G_GNUC_CONST;
 
 void hinoko_fw_iso_ctx_get_cycle_timer(HinokoFwIsoCtx *self, gint clock_id,
 				       HinokoCycleTimer *const *cycle_timer,

--- a/src/fw_iso_resource.c
+++ b/src/fw_iso_resource.c
@@ -19,9 +19,9 @@
  * of isochronous resource allocation/deallocation by file descriptor owned
  * internally. This object is designed to be used for any derived object.
  */
-struct _HinokoFwIsoResourcePrivate {
+typedef struct {
 	int fd;
-};
+} HinokoFwIsoResourcePrivate;
 G_DEFINE_TYPE_WITH_PRIVATE(HinokoFwIsoResource, hinoko_fw_iso_resource, G_TYPE_OBJECT)
 
 /**

--- a/src/fw_iso_resource.h
+++ b/src/fw_iso_resource.h
@@ -8,39 +8,12 @@ G_BEGIN_DECLS
 
 #define HINOKO_TYPE_FW_ISO_RESOURCE	(hinoko_fw_iso_resource_get_type())
 
-#define HINOKO_FW_ISO_RESOURCE(obj)					\
-	(G_TYPE_CHECK_INSTANCE_CAST((obj),				\
-					HINOKO_TYPE_FW_ISO_RESOURCE,	\
-					HinokoFwIsoResource))
-#define HINOKO_IS_FW_ISO_RESOURCE(obj)					\
-	(G_TYPE_CHECK_INSTANCE_TYPE((obj),				\
-				    HINOKO_TYPE_FW_ISO_RESOURCE))
-
-#define HINOKO_FW_ISO_RESOURCE_CLASS(klass)				\
-	(G_TYPE_CHECK_CLASS_CAST((klass),				\
-				 HINOKO_TYPE_FW_ISO_RESOURCE,		\
-				 HinokoFwIsoResourceClass))
-#define HINOKO_IS_FW_ISO_RESOURCE_CLASS(klass)				\
-	(G_TYPE_CHECK_CLASS_TYPE((klass),				\
-				 HINOKO_TYPE_FW_ISO_RESOURCE))
-#define HINOKO_FW_ISO_RESOURCE_GET_CLASS(obj)				\
-	(G_TYPE_INSTANCE_GET_CLASS((obj),				\
-				   HINOKO_TYPE_FW_ISO_RESOURCE,		\
-				   HinokoFwIsoResourceClass))
+G_DECLARE_DERIVABLE_TYPE(HinokoFwIsoResource, hinoko_fw_iso_resource, HINOKO, FW_ISO_RESOURCE,
+			 GObject);
 
 #define HINOKO_FW_ISO_RESOURCE_ERROR		hinoko_fw_iso_resource_error_quark()
 
 GQuark hinoko_fw_iso_resource_error_quark();
-
-typedef struct _HinokoFwIsoResource		HinokoFwIsoResource;
-typedef struct _HinokoFwIsoResourceClass	HinokoFwIsoResourceClass;
-typedef struct _HinokoFwIsoResourcePrivate	HinokoFwIsoResourcePrivate;
-
-struct _HinokoFwIsoResource {
-	GObject parent_instance;
-
-	HinokoFwIsoResourcePrivate *priv;
-};
 
 struct _HinokoFwIsoResourceClass {
 	GObjectClass parent_class;
@@ -75,8 +48,6 @@ struct _HinokoFwIsoResourceClass {
 	void (*deallocated)(HinokoFwIsoResource *self, guint channel,
 			    guint bandwidth, GError *error);
 };
-
-GType hinoko_fw_iso_resource_get_type(void) G_GNUC_CONST;
 
 HinokoFwIsoResource *hinoko_fw_iso_resource_new();
 

--- a/src/fw_iso_resource_auto.c
+++ b/src/fw_iso_resource_auto.c
@@ -14,15 +14,16 @@
  * kept even if the generation of the bus updates. The maintenance of allocated
  * isochronous resource is done by Linux FireWire subsystem.
  */
-struct _HinokoFwIsoResourceAutoPrivate {
+typedef struct {
 	gboolean allocated;
 	guint channel;
 	guint bandwidth;
 
 	GMutex mutex;
 	guint handle;
-};
-G_DEFINE_TYPE_WITH_PRIVATE(HinokoFwIsoResourceAuto, hinoko_fw_iso_resource_auto, HINOKO_TYPE_FW_ISO_RESOURCE)
+} HinokoFwIsoResourceAutoPrivate;
+G_DEFINE_TYPE_WITH_PRIVATE(HinokoFwIsoResourceAuto, hinoko_fw_iso_resource_auto,
+			   HINOKO_TYPE_FW_ISO_RESOURCE)
 
 /**
  * hinoko_fw_iso_resource_auto_error_quark:

--- a/src/fw_iso_resource_auto.h
+++ b/src/fw_iso_resource_auto.h
@@ -8,45 +8,16 @@ G_BEGIN_DECLS
 
 #define HINOKO_TYPE_FW_ISO_RESOURCE_AUTO	(hinoko_fw_iso_resource_auto_get_type())
 
-#define HINOKO_FW_ISO_RESOURCE_AUTO(obj)				\
-	(G_TYPE_CHECK_INSTANCE_CAST((obj),				\
-				    HINOKO_TYPE_FW_ISO_RESOURCE_AUTO,	\
-				    HinokoFwIsoResourceAuto))
-#define HINOKO_IS_FW_ISO_RESOURCE_AUTO(obj)				\
-	(G_TYPE_CHECK_INSTANCE_TYPE((obj),				\
-				    HINOKO_TYPE_FW_ISO_RESOURCE_AUTO))
-
-#define HINOKO_FW_ISO_RESOURCE_AUTO_CLASS(klass)			\
-	(G_TYPE_CHECK_CLASS_CAST((klass),				\
-				 HINOKO_TYPE_FW_ISO_RESOURCE_AUTO,	\
-				 HinokoFwIsoResourceAutoClass))
-#define HINOKO_IS_FW_ISO_RESOURCE_AUTO_CLASS(klass)			\
-	(G_TYPE_CHECK_CLASS_TYPE((klass),				\
-				 HINOKO_TYPE_FW_ISO_RESOURCE_AUTO))
-#define HINOKO_FW_ISO_RESOURCE_AUTO_GET_CLASS(obj)			\
-	(G_TYPE_INSTANCE_GET_CLASS((obj),				\
-				   HINOKO_TYPE_FW_ISO_RESOURCE_AUTO,	\
-				   HinokoFwIsoResourceAutoClass))
+G_DECLARE_DERIVABLE_TYPE(HinokoFwIsoResourceAuto, hinoko_fw_iso_resource_auto, HINOKO,
+			 FW_ISO_RESOURCE_AUTO, HinokoFwIsoResource);
 
 #define HINOKO_FW_ISO_RESOURCE_AUTO_ERROR	hinoko_fw_iso_resource_auto_error_quark()
 
 GQuark hinoko_fw_iso_resource_auto_error_quark();
 
-typedef struct _HinokoFwIsoResourceAuto		HinokoFwIsoResourceAuto;
-typedef struct _HinokoFwIsoResourceAutoClass	HinokoFwIsoResourceAutoClass;
-typedef struct _HinokoFwIsoResourceAutoPrivate	HinokoFwIsoResourceAutoPrivate;
-
-struct _HinokoFwIsoResourceAuto {
-	HinokoFwIsoResource parent_instance;
-
-	HinokoFwIsoResourceAutoPrivate *priv;
-};
-
 struct _HinokoFwIsoResourceAutoClass {
 	HinokoFwIsoResourceClass parent_class;
 };
-
-GType hinoko_fw_iso_resource_auto_get_type(void) G_GNUC_CONST;
 
 HinokoFwIsoResourceAuto *hinoko_fw_iso_resource_auto_new();
 

--- a/src/fw_iso_rx_multiple.c
+++ b/src/fw_iso_rx_multiple.c
@@ -17,7 +17,7 @@ struct ctx_payload {
 	unsigned int offset;
 	unsigned int length;
 };
-struct _HinokoFwIsoRxMultiplePrivate {
+typedef struct {
 	GByteArray *channels;
 
 	guint prev_offset;
@@ -28,9 +28,8 @@ struct _HinokoFwIsoRxMultiplePrivate {
 
 	guint chunks_per_irq;
 	guint accumulated_chunk_count;
-};
-G_DEFINE_TYPE_WITH_PRIVATE(HinokoFwIsoRxMultiple, hinoko_fw_iso_rx_multiple,
-			   HINOKO_TYPE_FW_ISO_CTX)
+} HinokoFwIsoRxMultiplePrivate;
+G_DEFINE_TYPE_WITH_PRIVATE(HinokoFwIsoRxMultiple, hinoko_fw_iso_rx_multiple, HINOKO_TYPE_FW_ISO_CTX)
 
 enum fw_iso_rx_multiple_prop_type {
 	FW_ISO_RX_MULTIPLE_PROP_TYPE_CHANNELS = 1,

--- a/src/fw_iso_rx_multiple.h
+++ b/src/fw_iso_rx_multiple.h
@@ -8,35 +8,8 @@ G_BEGIN_DECLS
 
 #define HINOKO_TYPE_FW_ISO_RX_MULTIPLE	(hinoko_fw_iso_rx_multiple_get_type())
 
-#define HINOKO_FW_ISO_RX_MULTIPLE(obj)					\
-	(G_TYPE_CHECK_INSTANCE_CAST((obj),				\
-				    HINOKO_TYPE_FW_ISO_RX_MULTIPLE,	\
-				    HinokoFwIsoRxMultiple))
-#define HINOKO_IS_FW_ISO_RX_MULTIPLE(obj)				\
-	(G_TYPE_CHECK_INSTANCE_TYPE((obj),				\
-				    HINOKO_TYPE_FW_ISO_RX_MULTIPLE))
-
-#define HINOKO_FW_ISO_RX_MULTIPLE_CLASS(klass)				\
-	(G_TYPE_CHECK_CLASS_CAST((klass),				\
-				 HINOKO_TYPE_FW_ISO_RX_MULTIPLE,	\
-				 HinokoFwIsoRxMultipleClass))
-#define HINOKO_IS_FW_ISO_RX_MULTIPLE_CLASS(klass)			\
-	(G_TYPE_CHECK_CLASS_TYPE((klass),				\
-				 HINOKO_TYPE_FW_ISO_RX_MULTIPLE))
-#define HINOKO_FW_ISO_RX_MULTIPLE_GET_CLASS(obj)			\
-	(G_TYPE_INSTANCE_GET_CLASS((obj),				\
-				   HINOKO_TYPE_FW_ISO_RX_MULTIPLE,	\
-				   HinokoFwIsoRxMultipleClass))
-
-typedef struct _HinokoFwIsoRxMultiple		HinokoFwIsoRxMultiple;
-typedef struct _HinokoFwIsoRxMultipleClass	HinokoFwIsoRxMultipleClass;
-typedef struct _HinokoFwIsoRxMultiplePrivate	HinokoFwIsoRxMultiplePrivate;
-
-struct _HinokoFwIsoRxMultiple {
-	HinokoFwIsoCtx parent_instance;
-
-	HinokoFwIsoRxMultiplePrivate *priv;
-};
+G_DECLARE_DERIVABLE_TYPE(HinokoFwIsoRxMultiple, hinoko_fw_iso_rx_multiple, HINOKO,
+			 FW_ISO_RX_MULTIPLE, HinokoFwIsoCtx);
 
 struct _HinokoFwIsoRxMultipleClass {
 	HinokoFwIsoCtxClass parent_class;
@@ -50,8 +23,6 @@ struct _HinokoFwIsoRxMultipleClass {
 	 */
 	void (*interrupted)(HinokoFwIsoRxMultiple *self, guint count);
 };
-
-GType hinoko_fw_iso_rx_multiple_get_type(void) G_GNUC_CONST;
 
 HinokoFwIsoRxMultiple *hinoko_fw_iso_rx_multiple_new(void);
 

--- a/src/fw_iso_rx_single.c
+++ b/src/fw_iso_rx_single.c
@@ -17,14 +17,13 @@
  * FireWire subsystem.
  *
  */
-struct _HinokoFwIsoRxSinglePrivate {
+typedef struct {
 	guint header_size;
 	guint chunk_cursor;
 
 	const struct fw_cdev_event_iso_interrupt *ev;
-};
-G_DEFINE_TYPE_WITH_PRIVATE(HinokoFwIsoRxSingle, hinoko_fw_iso_rx_single,
-			   HINOKO_TYPE_FW_ISO_CTX)
+} HinokoFwIsoRxSinglePrivate;
+G_DEFINE_TYPE_WITH_PRIVATE(HinokoFwIsoRxSingle, hinoko_fw_iso_rx_single, HINOKO_TYPE_FW_ISO_CTX)
 
 static void fw_iso_rx_single_finalize(GObject *obj)
 {

--- a/src/fw_iso_rx_single.h
+++ b/src/fw_iso_rx_single.h
@@ -8,35 +8,8 @@ G_BEGIN_DECLS
 
 #define HINOKO_TYPE_FW_ISO_RX_SINGLE	(hinoko_fw_iso_rx_single_get_type())
 
-#define HINOKO_FW_ISO_RX_SINGLE(obj)					\
-	(G_TYPE_CHECK_INSTANCE_CAST((obj),				\
-				    HINOKO_TYPE_FW_ISO_RX_SINGLE,	\
-				    HinokoFwIsoRxSingle))
-#define HINOKO_IS_FW_ISO_RX_SINGLE(obj)					\
-	(G_TYPE_CHECK_INSTANCE_TYPE((obj),				\
-				    HINOKO_TYPE_FW_ISO_RX_SINGLE))
-
-#define HINOKO_FW_ISO_RX_SINGLE_CLASS(klass)				\
-	(G_TYPE_CHECK_CLASS_CAST((klass),				\
-				 HINOKO_TYPE_FW_ISO_RX_SINGLE,		\
-				 HinokoFwIsoRxSingleClass))
-#define HINOKO_IS_FW_ISO_RX_SINGLE_CLASS(klass)				\
-	(G_TYPE_CHECK_CLASS_TYPE((klass),				\
-				 HINOKO_TYPE_FW_ISO_RX_SINGLE))
-#define HINOKO_FW_ISO_RX_SINGLE_GET_CLASS(obj)				\
-	(G_TYPE_INSTANCE_GET_CLASS((obj),				\
-				   HINOKO_TYPE_FW_ISO_RX_SINGLE,	\
-				   HinokoFwIsoRxSingleClass))
-
-typedef struct _HinokoFwIsoRxSingle		HinokoFwIsoRxSingle;
-typedef struct _HinokoFwIsoRxSingleClass	HinokoFwIsoRxSingleClass;
-typedef struct _HinokoFwIsoRxSinglePrivate	HinokoFwIsoRxSinglePrivate;
-
-struct _HinokoFwIsoRxSingle {
-	HinokoFwIsoCtx parent_instance;
-
-	HinokoFwIsoRxSinglePrivate *priv;
-};
+G_DECLARE_DERIVABLE_TYPE(HinokoFwIsoRxSingle, hinoko_fw_iso_rx_single, HINOKO, FW_ISO_RX_SINGLE,
+			 HinokoFwIsoCtx);
 
 struct _HinokoFwIsoRxSingleClass {
 	HinokoFwIsoCtxClass parent_class;
@@ -57,8 +30,6 @@ struct _HinokoFwIsoRxSingleClass {
 			    const guint8 *header, guint header_length,
 			    guint count);
 };
-
-GType hinoko_fw_iso_rx_single_get_type(void) G_GNUC_CONST;
 
 HinokoFwIsoRxSingle *hinoko_fw_iso_rx_single_new(void);
 

--- a/src/fw_iso_tx.c
+++ b/src/fw_iso_tx.c
@@ -15,11 +15,10 @@
  * context in 1394 OHCI. The content of packet is split to two parts; context
  * header and context payload in a manner of Linux FireWire subsystem.
  */
-struct _HinokoFwIsoTxPrivate {
+typedef struct {
 	guint offset;
-};
-G_DEFINE_TYPE_WITH_PRIVATE(HinokoFwIsoTx, hinoko_fw_iso_tx,
-			   HINOKO_TYPE_FW_ISO_CTX)
+} HinokoFwIsoTxPrivate;
+G_DEFINE_TYPE_WITH_PRIVATE(HinokoFwIsoTx, hinoko_fw_iso_tx, HINOKO_TYPE_FW_ISO_CTX)
 
 static void fw_iso_tx_finalize(GObject *obj)
 {

--- a/src/fw_iso_tx.h
+++ b/src/fw_iso_tx.h
@@ -8,35 +8,7 @@ G_BEGIN_DECLS
 
 #define HINOKO_TYPE_FW_ISO_TX	(hinoko_fw_iso_tx_get_type())
 
-#define HINOKO_FW_ISO_TX(obj)					\
-	(G_TYPE_CHECK_INSTANCE_CAST((obj),			\
-				    HINOKO_TYPE_FW_ISO_TX,	\
-				    HinokoFwIsoTx))
-#define HINOKO_IS_FW_ISO_TX(obj)				\
-	(G_TYPE_CHECK_INSTANCE_TYPE((obj),			\
-				    HINOKO_TYPE_FW_ISO_TX))
-
-#define HINOKO_FW_ISO_TX_CLASS(klass)				\
-	(G_TYPE_CHECK_CLASS_CAST((klass),			\
-				 HINOKO_TYPE_FW_ISO_TX,		\
-				 HinokoFwIsoTxClass))
-#define HINOKO_IS_FW_ISO_TX_CLASS(klass)			\
-	(G_TYPE_CHECK_CLASS_TYPE((klass),			\
-				 HINOKO_TYPE_FW_ISO_TX))
-#define HINOKO_FW_ISO_TX_GET_CLASS(obj)				\
-	(G_TYPE_INSTANCE_GET_CLASS((obj),			\
-				   HINOKO_TYPE_FW_ISO_TX,	\
-				   HinokoFwIsoTxClass))
-
-typedef struct _HinokoFwIsoTx		HinokoFwIsoTx;
-typedef struct _HinokoFwIsoTxClass	HinokoFwIsoTxClass;
-typedef struct _HinokoFwIsoTxPrivate	HinokoFwIsoTxPrivate;
-
-struct _HinokoFwIsoTx {
-	HinokoFwIsoCtx parent_instance;
-
-	HinokoFwIsoTxPrivate *priv;
-};
+G_DECLARE_DERIVABLE_TYPE(HinokoFwIsoTx, hinoko_fw_iso_tx, HINOKO, FW_ISO_TX, HinokoFwIsoCtx);
 
 struct _HinokoFwIsoTxClass {
 	HinokoFwIsoCtxClass parent_class;
@@ -57,8 +29,6 @@ struct _HinokoFwIsoTxClass {
 			    const guint8 *tstamp, guint tstamp_length,
 			    guint count);
 };
-
-GType hinoko_fw_iso_tx_get_type(void) G_GNUC_CONST;
 
 HinokoFwIsoTx *hinoko_fw_iso_tx_new(void);
 

--- a/src/meson.build
+++ b/src/meson.build
@@ -1,6 +1,6 @@
 # Depends on glib-2.0 and gobject-2.0.
 gobject = dependency('gobject-2.0',
-  version: '>=2.34.0'
+  version: '>=2.44.0'
 )
 dependencies = [
   gobject,


### PR DESCRIPTION
GObject v2.44 got new macro to declare GObject-derived objects. This enables us to reduce
boireplate for the declaration.

This patchset is to replace current boireplates with it.

```
Takashi Sakamoto (7):
  cycle_timer: minor code refactoring for inclusion guard
  fw_iso_ctx: use an utility macro to declare GObject-derived objects
  fw_iso_rx_single: use an utility macro to declare GObject-derived
    objects
  fw_iso_rx_multiple: use an utility macro to declare GObject-derived
    objects
  fw_iso_tx: use an utility macro to declare GObject-derived objects
  fw_iso_resource: use an utility macro to declare GObject-derived
    objects
  fw_iso_resource_auto: use an utility macro to declare GObject-derived
    objects

 README.rst                 |  2 +-
 src/cycle_timer.h          |  4 ++--
 src/fw_iso_ctx.c           | 24 +++++++++++-------------
 src/fw_iso_ctx.h           | 33 ++-------------------------------
 src/fw_iso_resource.c      |  4 ++--
 src/fw_iso_resource.h      | 33 ++-------------------------------
 src/fw_iso_resource_auto.c |  7 ++++---
 src/fw_iso_resource_auto.h | 33 ++-------------------------------
 src/fw_iso_rx_multiple.c   |  7 +++----
 src/fw_iso_rx_multiple.h   | 33 ++-------------------------------
 src/fw_iso_rx_single.c     |  7 +++----
 src/fw_iso_rx_single.h     | 33 ++-------------------------------
 src/fw_iso_tx.c            |  7 +++----
 src/fw_iso_tx.h            | 32 +-------------------------------
 src/meson.build            |  2 +-
 15 files changed, 41 insertions(+), 220 deletions(-)
```