### PR TITLE
[PATCH 00/19] rewrite public API according to convention of GNOME project

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@
 libhinoko
 =========
 
-2022/03/11
+2022/04/12
 Takashi Sakamoto
 
 Introduction
@@ -73,6 +73,42 @@ How to refer document
     $ cd build
     $ ninja
     $ ninja install
+
+Loss of backward compatibility between v0.6/v0.7 releases
+=========================================================
+
+The status of project is under development. Below public functions have been changed since v0.7
+release without backward compatibility:
+
+- ``Hinoko.FwIsoCtx.get_cycle_timer()``
+- ``Hinoko.FwIsoCtx.create_source()``
+- ``Hinoko.FwIsoCtx.flush_completions()``
+- ``Hinoko.FwIsoRxSingle.allocate()``
+- ``Hinoko.FwIsoRxSingle.map_buffer()``
+- ``Hinoko.FwIsoRxSingle.register_packet()``
+- ``Hinoko.FwIsoRxSingle.start()``
+- ``Hinoko.FwIsoRxSingle.get_payload()``
+- ``Hinoko.FwIsoRxMultiple.allocate()``
+- ``Hinoko.FwIsoRxMultiple.map_buffer()``
+- ``Hinoko.FwIsoRxMultiple.start()``
+- ``Hinoko.FwIsoRxMultiple.get_payload()``
+- ``Hinoko.FwIsoTx.allocate()``
+- ``Hinoko.FwIsoTx.map_buffer()``
+- ``Hinoko.FwIsoTx.start()``
+- ``Hinoko.FwIsoTx.register_packet()``
+- ``Hinoko.FwIsoResource.open()``
+- ``Hinoko.FwIsoResource.create_source()``
+- ``Hinoko.FwIsoResource.allocate_once_async()``
+- ``Hinoko.FwIsoResource.deallocate_once_async()``
+- ``Hinoko.FwIsoResource.allocate_once_sync()``
+- ``Hinoko.FwIsoResource.deallocate_once_sync()``
+- ``Hinoko.FwIsoResourceAuto.allocate_async()``
+- ``Hinoko.FwIsoResourceAuto.deallocate_async()``
+- ``Hinoko.FwIsoResourceAuto.allocate_sync()``
+- ``Hinoko.FwIsoResourceAuto.deallocate_sync()``
+
+They are rewritten to return value of gboolean type according to convension of GNOME project for
+throw functions which has an argument of GError to report failure.
 
 Loss of backward compatibility between v0.5/v0.6 releases
 =========================================================

--- a/src/fw_iso_ctx.c
+++ b/src/fw_iso_ctx.c
@@ -488,57 +488,62 @@ void hinoko_fw_iso_ctx_set_rx_channels(HinokoFwIsoCtx *self,
  * @exception: A #GError.
  *
  * Register data on buffer for payload of isochronous context.
+ *
+ * Returns: %TRUE if the overall operation finished successfully, otherwise %FALSE.
  */
-void hinoko_fw_iso_ctx_register_chunk(HinokoFwIsoCtx *self, gboolean skip,
-				      HinokoFwIsoCtxMatchFlag tags, guint sy,
-				      const guint8 *header, guint header_length,
-				      guint payload_length, gboolean schedule_interrupt,
-				      GError **exception)
+gboolean hinoko_fw_iso_ctx_register_chunk(HinokoFwIsoCtx *self, gboolean skip,
+					  HinokoFwIsoCtxMatchFlag tags, guint sy,
+					  const guint8 *header, guint header_length,
+					  guint payload_length, gboolean schedule_interrupt,
+					  GError **exception)
 {
 	HinokoFwIsoCtxPrivate *priv;
+
 	struct fw_cdev_iso_packet *datum;
 
-	g_return_if_fail(HINOKO_IS_FW_ISO_CTX(self));
-	g_return_if_fail(skip == TRUE || skip == FALSE);
-	g_return_if_fail(exception != NULL && *exception == NULL);
+	g_return_val_if_fail(HINOKO_IS_FW_ISO_CTX(self), FALSE);
+	g_return_val_if_fail(skip == TRUE || skip == FALSE, FALSE);
+	g_return_val_if_fail(exception != NULL && *exception == NULL, FALSE);
 
-	g_return_if_fail(tags == 0 ||
-			 tags == HINOKO_FW_ISO_CTX_MATCH_FLAG_TAG0 ||
-			 tags == HINOKO_FW_ISO_CTX_MATCH_FLAG_TAG1 ||
-			 tags == HINOKO_FW_ISO_CTX_MATCH_FLAG_TAG2 ||
-			 tags == HINOKO_FW_ISO_CTX_MATCH_FLAG_TAG3);
+	g_return_val_if_fail(tags == 0 ||
+			     tags == HINOKO_FW_ISO_CTX_MATCH_FLAG_TAG0 ||
+			     tags == HINOKO_FW_ISO_CTX_MATCH_FLAG_TAG1 ||
+			     tags == HINOKO_FW_ISO_CTX_MATCH_FLAG_TAG2 ||
+			     tags == HINOKO_FW_ISO_CTX_MATCH_FLAG_TAG3,
+			     FALSE);
 
-	g_return_if_fail(sy < 16);
+	g_return_val_if_fail(sy < 16, FALSE);
 
 	priv = hinoko_fw_iso_ctx_get_instance_private(self);
 	if (priv->mode == HINOKO_FW_ISO_CTX_MODE_TX) {
 		if (!skip) {
-			g_return_if_fail(header_length == priv->header_size);
-			g_return_if_fail(payload_length <= priv->bytes_per_chunk);
+			g_return_val_if_fail(header_length == priv->header_size, FALSE);
+			g_return_val_if_fail(payload_length <= priv->bytes_per_chunk, FALSE);
 		} else {
-			g_return_if_fail(payload_length == 0);
-			g_return_if_fail(header_length == 0);
-			g_return_if_fail(header == NULL);
+			g_return_val_if_fail(payload_length == 0, FALSE);
+			g_return_val_if_fail(header_length == 0, FALSE);
+			g_return_val_if_fail(header == NULL, FALSE);
 		}
 	} else if (priv->mode == HINOKO_FW_ISO_CTX_MODE_RX_SINGLE ||
 		   priv->mode == HINOKO_FW_ISO_CTX_MODE_RX_MULTIPLE) {
-		g_return_if_fail(tags == 0);
-		g_return_if_fail(sy == 0);
-		g_return_if_fail(header == NULL);
-		g_return_if_fail(header_length == 0);
-		g_return_if_fail(payload_length == 0);
+		g_return_val_if_fail(tags == 0, FALSE);
+		g_return_val_if_fail(sy == 0, FALSE);
+		g_return_val_if_fail(header == NULL, FALSE);
+		g_return_val_if_fail(header_length == 0, FALSE);
+		g_return_val_if_fail(payload_length == 0, FALSE);
 	}
 
-	g_return_if_fail(priv->data_length + sizeof(*datum) + header_length <= priv->alloc_data_length);
+	g_return_val_if_fail(priv->data_length + sizeof(*datum) + header_length <= priv->alloc_data_length,
+			     FALSE);
 
 	if (priv->fd < 0) {
 		generate_local_error(exception, HINOKO_FW_ISO_CTX_ERROR_NOT_ALLOCATED);
-		return;
+		return FALSE;
 	}
 
 	if (priv->addr == NULL) {
 		generate_local_error(exception, HINOKO_FW_ISO_CTX_ERROR_NOT_MAPPED);
-		return;
+		return FALSE;
 	}
 
 	datum = (struct fw_cdev_iso_packet *)(priv->data + priv->data_length);
@@ -566,6 +571,8 @@ void hinoko_fw_iso_ctx_register_chunk(HinokoFwIsoCtx *self, gboolean skip,
 
 	if (schedule_interrupt)
 		datum->control |= FW_CDEV_ISO_INTERRUPT;
+
+	return TRUE;
 }
 
 static void fw_iso_ctx_queue_chunks(HinokoFwIsoCtx *self, GError **exception)

--- a/src/fw_iso_ctx.c
+++ b/src/fw_iso_ctx.c
@@ -324,28 +324,30 @@ void hinoko_fw_iso_ctx_release(HinokoFwIsoCtx *self)
  *
  * Map intermediate buffer to share payload of isochronous context with 1394
  * OHCI controller.
+ *
+ * Returns: %TRUE if the overall operation finished successfully, otherwise %FALSE.
  */
-void hinoko_fw_iso_ctx_map_buffer(HinokoFwIsoCtx *self, guint bytes_per_chunk,
-				  guint chunks_per_buffer, GError **exception)
+gboolean hinoko_fw_iso_ctx_map_buffer(HinokoFwIsoCtx *self, guint bytes_per_chunk,
+				      guint chunks_per_buffer, GError **exception)
 {
 	HinokoFwIsoCtxPrivate *priv;
 	unsigned int datum_size;
 	int prot;
 
-	g_return_if_fail(HINOKO_IS_FW_ISO_CTX(self));
-	g_return_if_fail(bytes_per_chunk > 0);
-	g_return_if_fail(chunks_per_buffer > 0);
-	g_return_if_fail(exception != NULL && *exception == NULL);
+	g_return_val_if_fail(HINOKO_IS_FW_ISO_CTX(self), FALSE);
+	g_return_val_if_fail(bytes_per_chunk > 0, FALSE);
+	g_return_val_if_fail(chunks_per_buffer > 0, FALSE);
+	g_return_val_if_fail(exception != NULL && *exception == NULL, FALSE);
 	priv = hinoko_fw_iso_ctx_get_instance_private(self);
 
 	if (priv->fd < 0) {
 		generate_local_error(exception, HINOKO_FW_ISO_CTX_ERROR_NOT_ALLOCATED);
-		return;
+		return FALSE;
 	}
 
 	if (priv->addr != NULL) {
 		generate_local_error(exception, HINOKO_FW_ISO_CTX_ERROR_MAPPED);
-		return;
+		return FALSE;
 	}
 
 	datum_size = sizeof(struct fw_cdev_iso_packet);
@@ -366,11 +368,13 @@ void hinoko_fw_iso_ctx_map_buffer(HinokoFwIsoCtx *self, guint bytes_per_chunk,
 	if (priv->addr == MAP_FAILED) {
 		generate_syscall_error(exception, errno,
 				       "mmap(%d)", bytes_per_chunk * chunks_per_buffer);
-		return;
+		return FALSE;
 	}
 
 	priv->bytes_per_chunk = bytes_per_chunk;
 	priv->chunks_per_buffer = chunks_per_buffer;
+
+	return TRUE;
 }
 
 /**

--- a/src/fw_iso_ctx.h
+++ b/src/fw_iso_ctx.h
@@ -25,7 +25,7 @@ struct _HinokoFwIsoCtxClass {
 	 * When isochronous context is stopped, #HinokoFwIsoCtxClass::stopped
 	 * handler is called. When any error occurs, it's reported.
 	 */
-	void (*stopped)(HinokoFwIsoCtx *self, GError *error);
+	void (*stopped)(HinokoFwIsoCtx *self, const GError *error);
 };
 
 

--- a/src/fw_iso_ctx.h
+++ b/src/fw_iso_ctx.h
@@ -29,14 +29,13 @@ struct _HinokoFwIsoCtxClass {
 };
 
 
-void hinoko_fw_iso_ctx_get_cycle_timer(HinokoFwIsoCtx *self, gint clock_id,
+gboolean hinoko_fw_iso_ctx_get_cycle_timer(HinokoFwIsoCtx *self, gint clock_id,
 				       HinokoCycleTimer *const *cycle_timer,
 				       GError **exception);
 
-void hinoko_fw_iso_ctx_create_source(HinokoFwIsoCtx *self, GSource **gsrc,
-				     GError **exception);
+gboolean hinoko_fw_iso_ctx_create_source(HinokoFwIsoCtx *self, GSource **gsrc, GError **exception);
 
-void hinoko_fw_iso_ctx_flush_completions(HinokoFwIsoCtx *self, GError **exception);
+gboolean hinoko_fw_iso_ctx_flush_completions(HinokoFwIsoCtx *self, GError **exception);
 
 G_END_DECLS
 

--- a/src/fw_iso_resource.c
+++ b/src/fw_iso_resource.c
@@ -166,20 +166,24 @@ HinokoFwIsoResource *hinoko_fw_iso_resource_new()
  *
  * Open Linux FireWire character device to delegate any request for isochronous
  * resource management to Linux FireWire subsystem.
+ *
+ * Returns: %TRUE if the overall operation finished successfully, otherwise %FALSE.
+ *
+ * Since: 0.7.
  */
-void hinoko_fw_iso_resource_open(HinokoFwIsoResource *self, const gchar *path,
-				 gint open_flag, GError **exception)
+gboolean hinoko_fw_iso_resource_open(HinokoFwIsoResource *self, const gchar *path, gint open_flag,
+				     GError **exception)
 {
 	HinokoFwIsoResourcePrivate *priv;
 
-	g_return_if_fail(HINOKO_IS_FW_ISO_RESOURCE(self));
-	g_return_if_fail(exception != NULL && *exception == NULL);
+	g_return_val_if_fail(HINOKO_IS_FW_ISO_RESOURCE(self), FALSE);
+	g_return_val_if_fail(exception != NULL && *exception == NULL, FALSE);
 
 	priv = hinoko_fw_iso_resource_get_instance_private(self);
 
 	if (priv->fd >= 0) {
 		generate_local_error(exception, HINOKO_FW_ISO_RESOURCE_ERROR_OPENED);
-		return;
+		return FALSE;
 	}
 
 	open_flag |= O_RDONLY;
@@ -190,7 +194,10 @@ void hinoko_fw_iso_resource_open(HinokoFwIsoResource *self, const gchar *path,
 			generate_file_error(exception, code, "open(%s)", path);
 		else
 			generate_syscall_error(exception, errno, "open(%s)", path);
+		return FALSE;
 	}
+
+	return TRUE;
 }
 
 /**
@@ -207,29 +214,32 @@ void hinoko_fw_iso_resource_open(HinokoFwIsoResource *self, const gchar *path,
  * Initiate allocation of isochronous resource without any wait. When the
  * allocation finishes, #HinokoFwIsoResource::allocated signal is emit to notify the result,
  * channel, and bandwidth.
+ *
+ * Returns: %TRUE if the overall operation finished successfully, otherwise %FALSE.
+ *
+ * Since: 0.7.
  */
-void hinoko_fw_iso_resource_allocate_once_async(HinokoFwIsoResource *self,
-						guint8 *channel_candidates,
-						gsize channel_candidates_count,
-						guint bandwidth,
-						GError **exception)
+gboolean hinoko_fw_iso_resource_allocate_once_async(HinokoFwIsoResource *self,
+						    guint8 *channel_candidates,
+						    gsize channel_candidates_count, guint bandwidth,
+						    GError **exception)
 {
 	HinokoFwIsoResourcePrivate *priv;
 	struct fw_cdev_allocate_iso_resource res = {0};
 	int i;
 
-	g_return_if_fail(HINOKO_IS_FW_ISO_RESOURCE(self));
-	g_return_if_fail(exception != NULL && *exception == NULL);
+	g_return_val_if_fail(HINOKO_IS_FW_ISO_RESOURCE(self), FALSE);
+	g_return_val_if_fail(exception != NULL && *exception == NULL, FALSE);
 
 	priv = hinoko_fw_iso_resource_get_instance_private(self);
 	if (priv->fd < 0) {
 		generate_local_error(exception, HINOKO_FW_ISO_RESOURCE_ERROR_NOT_OPENED);
-		return;
+		return FALSE;
 	}
 
-	g_return_if_fail(channel_candidates != NULL);
-	g_return_if_fail(channel_candidates_count > 0);
-	g_return_if_fail(bandwidth > 0);
+	g_return_val_if_fail(channel_candidates != NULL, FALSE);
+	g_return_val_if_fail(channel_candidates_count > 0, FALSE);
+	g_return_val_if_fail(bandwidth > 0, FALSE);
 
 	for (i = 0; i < channel_candidates_count; ++i) {
 		if (channel_candidates[i] < 64)
@@ -237,8 +247,12 @@ void hinoko_fw_iso_resource_allocate_once_async(HinokoFwIsoResource *self,
 	}
 	res.bandwidth = bandwidth;
 
-	if (ioctl(priv->fd, FW_CDEV_IOC_ALLOCATE_ISO_RESOURCE_ONCE, &res) < 0)
+	if (ioctl(priv->fd, FW_CDEV_IOC_ALLOCATE_ISO_RESOURCE_ONCE, &res) < 0) {
 		generate_syscall_error(exception, errno, "ioctl(%s)", "FW_CDEV_IOC_ALLOCATE_ISO_RESOURCE_ONCE");
+		return FALSE;
+	}
+
+	return TRUE;
 }
 
 /**
@@ -252,32 +266,38 @@ void hinoko_fw_iso_resource_allocate_once_async(HinokoFwIsoResource *self,
  * Initiate deallocation of isochronous resource without any wait. When the
  * deallocation finishes, #HinokoFwIsoResource::deallocated signal is emit to notify the result,
  * channel, and bandwidth.
+ *
+ * Returns: %TRUE if the overall operation finished successfully, otherwise %FALSE.
+ *
+ * Since: 0.7.
  */
-void hinoko_fw_iso_resource_deallocate_once_async(HinokoFwIsoResource *self,
-						  guint channel,
-						  guint bandwidth,
-						  GError **exception)
+gboolean hinoko_fw_iso_resource_deallocate_once_async(HinokoFwIsoResource *self, guint channel,
+						      guint bandwidth, GError **exception)
 {
 	HinokoFwIsoResourcePrivate *priv;
 	struct fw_cdev_allocate_iso_resource res = {0};
 
-	g_return_if_fail(HINOKO_IS_FW_ISO_RESOURCE(self));
-	g_return_if_fail(exception != NULL && *exception == NULL);
+	g_return_val_if_fail(HINOKO_IS_FW_ISO_RESOURCE(self), FALSE);
+	g_return_val_if_fail(exception != NULL && *exception == NULL, FALSE);
 
 	priv = hinoko_fw_iso_resource_get_instance_private(self);
 	if (priv->fd < 0) {
 		generate_local_error(exception, HINOKO_FW_ISO_RESOURCE_ERROR_NOT_OPENED);
-		return;
+		return FALSE;
 	}
 
-	g_return_if_fail(channel < 64);
-	g_return_if_fail(bandwidth > 0);
+	g_return_val_if_fail(channel < 64, FALSE);
+	g_return_val_if_fail(bandwidth > 0, FALSE);
 
 	res.channels = 1ull << channel;
 	res.bandwidth = bandwidth;
 
-	if (ioctl(priv->fd, FW_CDEV_IOC_DEALLOCATE_ISO_RESOURCE_ONCE, &res) < 0)
+	if (ioctl(priv->fd, FW_CDEV_IOC_DEALLOCATE_ISO_RESOURCE_ONCE, &res) < 0) {
 		generate_syscall_error(exception, errno, "ioctl(%s)", "FW_CDEV_IOC_DEALLOCATE_ISO_RESOURCE_ONCE");
+		return FALSE;
+	}
+
+	return TRUE;
 }
 
 struct waiter {
@@ -313,19 +333,22 @@ static void handle_event_signal(HinokoFwIsoResource *self, guint channel,
  *	       #hinoko_fw_iso_resource_error_quark().
  *
  * Initiate allocation of isochronous resource and wait for #HinokoFwIsoResource::allocated signal.
+ *
+ * Returns: %TRUE if the overall operation finished successfully, otherwise %FALSE.
+ *
+ * Since: 0.7.
  */
-void hinoko_fw_iso_resource_allocate_once_sync(HinokoFwIsoResource *self,
-					       guint8 *channel_candidates,
-					       gsize channel_candidates_count,
-					       guint bandwidth,
-					       GError **exception)
+gboolean hinoko_fw_iso_resource_allocate_once_sync(HinokoFwIsoResource *self,
+						   guint8 *channel_candidates,
+						   gsize channel_candidates_count, guint bandwidth,
+						   GError **exception)
 {
 	struct waiter w;
 	guint64 expiration;
 	gulong handler_id;
 
-	g_return_if_fail(HINOKO_IS_FW_ISO_RESOURCE(self));
-	g_return_if_fail(exception != NULL && *exception == NULL);
+	g_return_val_if_fail(HINOKO_IS_FW_ISO_RESOURCE(self), FALSE);
+	g_return_val_if_fail(exception != NULL && *exception == NULL, FALSE);
 
 	g_mutex_init(&w.mutex);
 	g_cond_init(&w.cond);
@@ -338,12 +361,11 @@ void hinoko_fw_iso_resource_allocate_once_sync(HinokoFwIsoResource *self,
 	handler_id = g_signal_connect(self, "allocated",
 				      (GCallback)handle_event_signal, &w);
 
-	hinoko_fw_iso_resource_allocate_once_async(self, channel_candidates,
-						   channel_candidates_count,
-						   bandwidth, exception);
-	if (*exception != NULL) {
+	if (!hinoko_fw_iso_resource_allocate_once_async(self, channel_candidates,
+							channel_candidates_count, bandwidth,
+							exception)) {
 		g_signal_handler_disconnect(self, handler_id);
-		return;
+		return FALSE;
 	}
 
 	g_mutex_lock(&w.mutex);
@@ -354,10 +376,15 @@ void hinoko_fw_iso_resource_allocate_once_sync(HinokoFwIsoResource *self,
 	g_signal_handler_disconnect(self, handler_id);
 	g_mutex_unlock(&w.mutex);
 
-	if (w.handled == FALSE)
+	if (w.handled == FALSE) {
 		generate_local_error(exception, HINOKO_FW_ISO_RESOURCE_ERROR_TIMEOUT);
-	else if (w.error != NULL)
+		return FALSE;
+	} else if (w.error != NULL) {
 		*exception = w.error;	// Delegate ownership.
+		return FALSE;
+	}
+
+	return TRUE;
 }
 
 /**
@@ -370,18 +397,20 @@ void hinoko_fw_iso_resource_allocate_once_sync(HinokoFwIsoResource *self,
  *
  * Initiate deallocation of isochronous resource. When the deallocation is done,
  * #HinokoFwIsoResource::deallocated signal is emit to notify the result, channel, and bandwidth.
+ *
+ * Returns: %TRUE if the overall operation finished successfully, otherwise %FALSE.
+ *
+ * Since: 0.7.
  */
-void hinoko_fw_iso_resource_deallocate_once_sync(HinokoFwIsoResource *self,
-						 guint channel,
-						 guint bandwidth,
-						 GError **exception)
+gboolean hinoko_fw_iso_resource_deallocate_once_sync(HinokoFwIsoResource *self, guint channel,
+						     guint bandwidth, GError **exception)
 {
 	struct waiter w;
 	guint64 expiration;
 	gulong handler_id;
 
-	g_return_if_fail(HINOKO_IS_FW_ISO_RESOURCE(self));
-	g_return_if_fail(exception != NULL && *exception == NULL);
+	g_return_val_if_fail(HINOKO_IS_FW_ISO_RESOURCE(self), FALSE);
+	g_return_val_if_fail(exception != NULL && *exception == NULL, FALSE);
 
 	g_mutex_init(&w.mutex);
 	g_cond_init(&w.cond);
@@ -394,11 +423,9 @@ void hinoko_fw_iso_resource_deallocate_once_sync(HinokoFwIsoResource *self,
 	handler_id = g_signal_connect(self, "deallocated",
 				      (GCallback)handle_event_signal, &w);
 
-	hinoko_fw_iso_resource_deallocate_once_async(self, channel, bandwidth,
-						     exception);
-	if (*exception != NULL) {
+	if (!hinoko_fw_iso_resource_deallocate_once_async(self, channel, bandwidth, exception)) {
 		g_signal_handler_disconnect(self, handler_id);
-		return;
+		return FALSE;
 	}
 
 	g_mutex_lock(&w.mutex);
@@ -409,10 +436,15 @@ void hinoko_fw_iso_resource_deallocate_once_sync(HinokoFwIsoResource *self,
 	g_signal_handler_disconnect(self, handler_id);
 	g_mutex_unlock(&w.mutex);
 
-	if (w.handled == FALSE)
+	if (w.handled == FALSE) {
 		generate_local_error(exception, HINOKO_FW_ISO_RESOURCE_ERROR_TIMEOUT);
-	else if (w.error != NULL)
+		return FALSE;
+	} else if (w.error != NULL) {
 		*exception = w.error;	// Delegate ownership.
+		return FALSE;
+	}
+
+	return TRUE;
 }
 
 // For internal use.
@@ -564,9 +596,13 @@ static void finalize_src(GSource *gsrc)
  * @exception: A #GError.
  *
  * Create Gsource for GMainContext to dispatch events for isochronous resource.
+ *
+ * Returns: %TRUE if the overall operation finished successfully, otherwise %FALSE.
+ *
+ * Since: 0.7.
  */
-void hinoko_fw_iso_resource_create_source(HinokoFwIsoResource *self,
-					  GSource **gsrc, GError **exception)
+gboolean hinoko_fw_iso_resource_create_source(HinokoFwIsoResource *self, GSource **gsrc,
+					      GError **exception)
 {
 	static GSourceFuncs funcs = {
 		.check		= check_src,
@@ -577,8 +613,8 @@ void hinoko_fw_iso_resource_create_source(HinokoFwIsoResource *self,
 	HinokoFwIsoResourcePrivate *priv;
 	FwIsoResourceSource *src;
 
-	g_return_if_fail(HINOKO_IS_FW_ISO_RESOURCE(self));
-	g_return_if_fail(exception != NULL && *exception == NULL);
+	g_return_val_if_fail(HINOKO_IS_FW_ISO_RESOURCE(self), FALSE);
+	g_return_val_if_fail(exception != NULL && *exception == NULL, FALSE);
 
 	priv = hinoko_fw_iso_resource_get_instance_private(self);
 
@@ -595,6 +631,8 @@ void hinoko_fw_iso_resource_create_source(HinokoFwIsoResource *self,
 	src->len = (gsize)page_size;
 	src->tag = g_source_add_unix_fd(*gsrc, priv->fd, G_IO_IN);
 	src->self = g_object_ref(self);
+
+	return TRUE;
 }
 
 /**

--- a/src/fw_iso_resource.c
+++ b/src/fw_iso_resource.c
@@ -416,20 +416,20 @@ void hinoko_fw_iso_resource_deallocate_once_sync(HinokoFwIsoResource *self,
 }
 
 // For internal use.
-void hinoko_fw_iso_resource_ioctl(HinokoFwIsoResource *self,
-				  unsigned long request, void *argp,
-				  GError **exception)
+gboolean hinoko_fw_iso_resource_ioctl(HinokoFwIsoResource *self, unsigned long request, void *argp,
+				      GError **exception)
 {
 	HinokoFwIsoResourcePrivate *priv;
 
-	g_return_if_fail(HINOKO_IS_FW_ISO_RESOURCE(self));
-	g_return_if_fail(request == FW_CDEV_IOC_ALLOCATE_ISO_RESOURCE ||
-			 request == FW_CDEV_IOC_DEALLOCATE_ISO_RESOURCE);
+	g_return_val_if_fail(HINOKO_IS_FW_ISO_RESOURCE(self), FALSE);
+	g_return_val_if_fail(request == FW_CDEV_IOC_ALLOCATE_ISO_RESOURCE ||
+			     request == FW_CDEV_IOC_DEALLOCATE_ISO_RESOURCE,
+			     FALSE);
 
 	priv = hinoko_fw_iso_resource_get_instance_private(self);
 	if (priv->fd < 0) {
 		generate_local_error(exception, HINOKO_FW_ISO_RESOURCE_ERROR_NOT_OPENED);
-		return;
+		return FALSE;
 	}
 
 	if (ioctl(priv->fd, request, argp) < 0) {
@@ -447,7 +447,10 @@ void hinoko_fw_iso_resource_ioctl(HinokoFwIsoResource *self,
 			break;
 		}
 		generate_syscall_error(exception, errno, "ioctl(%s)", arg);
+		return FALSE;
 	}
+
+	return TRUE;
 }
 
 static void handle_iso_resource_event(HinokoFwIsoResource *self,

--- a/src/fw_iso_resource.h
+++ b/src/fw_iso_resource.h
@@ -82,4 +82,6 @@ void hinoko_fw_iso_resource_deallocate_once_sync(HinokoFwIsoResource *self,
 						 guint bandwidth,
 						 GError **exception);
 
+G_END_DECLS
+
 #endif

--- a/src/fw_iso_resource.h
+++ b/src/fw_iso_resource.h
@@ -51,36 +51,30 @@ struct _HinokoFwIsoResourceClass {
 
 HinokoFwIsoResource *hinoko_fw_iso_resource_new();
 
-void hinoko_fw_iso_resource_open(HinokoFwIsoResource *self, const gchar *path,
-				 gint open_flag, GError **exception);
+gboolean hinoko_fw_iso_resource_open(HinokoFwIsoResource *self, const gchar *path, gint open_flag,
+				     GError **exception);
 
-void hinoko_fw_iso_resource_create_source(HinokoFwIsoResource *self,
-					  GSource **gsrc, GError **exception);
+gboolean hinoko_fw_iso_resource_create_source(HinokoFwIsoResource *self, GSource **gsrc,
+					      GError **exception);
 
 guint hinoko_fw_iso_resource_calculate_bandwidth(guint bytes_per_payload,
 						 HinokoFwScode scode);
 
-void hinoko_fw_iso_resource_allocate_once_async(HinokoFwIsoResource *self,
-						guint8 *channel_candidates,
-						gsize channel_candidates_count,
-						guint bandwidth,
-						GError **exception);
+gboolean hinoko_fw_iso_resource_allocate_once_async(HinokoFwIsoResource *self,
+						    guint8 *channel_candidates,
+						    gsize channel_candidates_count, guint bandwidth,
+						    GError **exception);
 
-void hinoko_fw_iso_resource_deallocate_once_async(HinokoFwIsoResource *self,
-						  guint channel,
-						  guint bandwidth,
-						  GError **exception);
+gboolean hinoko_fw_iso_resource_deallocate_once_async(HinokoFwIsoResource *self, guint channel,
+						      guint bandwidth, GError **exception);
 
-void hinoko_fw_iso_resource_allocate_once_sync(HinokoFwIsoResource *self,
-					       guint8 *channel_candidates,
-					       gsize channel_candidates_count,
-					       guint bandwidth,
-					       GError **exception);
+gboolean hinoko_fw_iso_resource_allocate_once_sync(HinokoFwIsoResource *self,
+						   guint8 *channel_candidates,
+						   gsize channel_candidates_count, guint bandwidth,
+						   GError **exception);
 
-void hinoko_fw_iso_resource_deallocate_once_sync(HinokoFwIsoResource *self,
-						 guint channel,
-						 guint bandwidth,
-						 GError **exception);
+gboolean hinoko_fw_iso_resource_deallocate_once_sync(HinokoFwIsoResource *self, guint channel,
+						     guint bandwidth, GError **exception);
 
 G_END_DECLS
 

--- a/src/fw_iso_resource.h
+++ b/src/fw_iso_resource.h
@@ -46,7 +46,7 @@ struct _HinokoFwIsoResourceClass {
 	 * handler is called to notify the result, channel, and bandwidth.
 	 */
 	void (*deallocated)(HinokoFwIsoResource *self, guint channel,
-			    guint bandwidth, GError *error);
+			    guint bandwidth, const GError *error);
 };
 
 HinokoFwIsoResource *hinoko_fw_iso_resource_new();

--- a/src/fw_iso_resource_auto.c
+++ b/src/fw_iso_resource_auto.c
@@ -175,10 +175,8 @@ void hinoko_fw_iso_resource_auto_allocate_async(HinokoFwIsoResourceAuto *self,
 	}
 	res.bandwidth = bandwidth;
 
-	hinoko_fw_iso_resource_ioctl(HINOKO_FW_ISO_RESOURCE(self),
-				     FW_CDEV_IOC_ALLOCATE_ISO_RESOURCE, &res,
-				     exception);
-	if (*exception == NULL)
+	if (hinoko_fw_iso_resource_ioctl(HINOKO_FW_ISO_RESOURCE(self),
+					 FW_CDEV_IOC_ALLOCATE_ISO_RESOURCE, &res, exception))
 		priv->handle = res.handle;
 end:
 	g_mutex_unlock(&priv->mutex);

--- a/src/fw_iso_resource_auto.c
+++ b/src/fw_iso_resource_auto.c
@@ -118,7 +118,7 @@ static void hinoko_fw_iso_resource_auto_init(HinokoFwIsoResourceAuto *self)
 }
 
 /**
- * hinoko_fw_iso_resource_auto:
+ * hinoko_fw_iso_resource_auto_new:
  *
  * Allocate and return an instance of #HinokoFwIsoResourceAuto object.
  *

--- a/src/fw_iso_resource_auto.h
+++ b/src/fw_iso_resource_auto.h
@@ -37,4 +37,6 @@ void hinoko_fw_iso_resource_auto_deallocate_async(HinokoFwIsoResourceAuto *self,
 void hinoko_fw_iso_resource_auto_deallocate_sync(HinokoFwIsoResourceAuto *self,
 						 GError **exception);
 
+G_END_DECLS
+
 #endif

--- a/src/fw_iso_resource_auto.h
+++ b/src/fw_iso_resource_auto.h
@@ -21,21 +21,19 @@ struct _HinokoFwIsoResourceAutoClass {
 
 HinokoFwIsoResourceAuto *hinoko_fw_iso_resource_auto_new();
 
-void hinoko_fw_iso_resource_auto_allocate_async(HinokoFwIsoResourceAuto *self,
-						guint8 *channel_candidates,
-						gsize channel_candidates_count,
-						guint bandwidth,
-						GError **exception);
-void hinoko_fw_iso_resource_auto_allocate_sync(HinokoFwIsoResourceAuto *self,
-					       guint8 *channel_candidates,
-					       gsize channel_candidates_count,
-					       guint bandwidth,
-					       GError **exception);
+gboolean hinoko_fw_iso_resource_auto_allocate_async(HinokoFwIsoResourceAuto *self,
+						    guint8 *channel_candidates,
+						    gsize channel_candidates_count, guint bandwidth,
+						    GError **exception);
+gboolean hinoko_fw_iso_resource_auto_allocate_sync(HinokoFwIsoResourceAuto *self,
+						   guint8 *channel_candidates,
+						   gsize channel_candidates_count, guint bandwidth,
+						   GError **exception);
 
-void hinoko_fw_iso_resource_auto_deallocate_async(HinokoFwIsoResourceAuto *self,
-						  GError **exception);
-void hinoko_fw_iso_resource_auto_deallocate_sync(HinokoFwIsoResourceAuto *self,
-						 GError **exception);
+gboolean hinoko_fw_iso_resource_auto_deallocate_async(HinokoFwIsoResourceAuto *self,
+						      GError **exception);
+gboolean hinoko_fw_iso_resource_auto_deallocate_sync(HinokoFwIsoResourceAuto *self,
+						     GError **exception);
 
 G_END_DECLS
 

--- a/src/fw_iso_rx_multiple.c
+++ b/src/fw_iso_rx_multiple.c
@@ -295,8 +295,7 @@ void hinoko_fw_iso_rx_multiple_unmap_buffer(HinokoFwIsoRxMultiple *self)
 	priv->concat_frames = NULL;
 }
 
-static void fw_iso_rx_multiple_register_chunk(HinokoFwIsoRxMultiple *self,
-					      GError **exception)
+static gboolean fw_iso_rx_multiple_register_chunk(HinokoFwIsoRxMultiple *self, GError **exception)
 {
 	HinokoFwIsoRxMultiplePrivate *priv = hinoko_fw_iso_rx_multiple_get_instance_private(self);
 	gboolean schedule_irq = FALSE;
@@ -308,8 +307,8 @@ static void fw_iso_rx_multiple_register_chunk(HinokoFwIsoRxMultiple *self,
 			priv->accumulated_chunk_count %= priv->chunks_per_irq;
 	}
 
-	hinoko_fw_iso_ctx_register_chunk(HINOKO_FW_ISO_CTX(self), FALSE, 0, 0, NULL, 0, 0,
-					 schedule_irq, exception);
+	return hinoko_fw_iso_ctx_register_chunk(HINOKO_FW_ISO_CTX(self), FALSE, 0, 0, NULL, 0, 0,
+						schedule_irq, exception);
 }
 
 /**
@@ -351,8 +350,7 @@ void hinoko_fw_iso_rx_multiple_start(HinokoFwIsoRxMultiple *self,
 	priv->accumulated_chunk_count = 0;
 
 	for (i = 0; i < chunks_per_buffer; ++i) {
-		fw_iso_rx_multiple_register_chunk(self, exception);
-		if (*exception != NULL)
+		if (!fw_iso_rx_multiple_register_chunk(self, exception))
 			return;
 	}
 
@@ -450,8 +448,7 @@ void hinoko_fw_iso_rx_multiple_handle_event(HinokoFwIsoRxMultiple *self,
 	chunk_pos = priv->prev_offset / bytes_per_chunk;
 	chunk_end = (priv->prev_offset + accum_length) / bytes_per_chunk;
 	for (; chunk_pos < chunk_end; ++chunk_pos) {
-		fw_iso_rx_multiple_register_chunk(self, exception);
-		if (*exception != NULL)
+		if (!fw_iso_rx_multiple_register_chunk(self, exception))
 			return;
 	}
 

--- a/src/fw_iso_rx_multiple.c
+++ b/src/fw_iso_rx_multiple.c
@@ -181,9 +181,7 @@ void hinoko_fw_iso_rx_multiple_allocate(HinokoFwIsoRxMultiple *self,
 					HINOKO_FW_ISO_CTX_MODE_RX_MULTIPLE, 0, 0, 0, exception))
 		return;
 
-	hinoko_fw_iso_ctx_set_rx_channels(HINOKO_FW_ISO_CTX(self),
-					  &channel_flags, exception);
-	if (*exception != NULL)
+	if (!hinoko_fw_iso_ctx_set_rx_channels(HINOKO_FW_ISO_CTX(self), &channel_flags, exception))
 		return;
 	if (channel_flags == 0) {
 		g_set_error_literal(exception, HINOKO_FW_ISO_CTX_ERROR,

--- a/src/fw_iso_rx_multiple.c
+++ b/src/fw_iso_rx_multiple.c
@@ -259,8 +259,9 @@ void hinoko_fw_iso_rx_multiple_map_buffer(HinokoFwIsoRxMultiple *self,
 
 	priv->concat_frames = g_malloc_n(4, bytes_per_chunk);
 
-	hinoko_fw_iso_ctx_map_buffer(HINOKO_FW_ISO_CTX(self), bytes_per_chunk,
-				     chunks_per_buffer, exception);
+	if (!hinoko_fw_iso_ctx_map_buffer(HINOKO_FW_ISO_CTX(self), bytes_per_chunk,
+					  chunks_per_buffer, exception))
+		return;
 
 	g_object_get(G_OBJECT(self),
 		     "bytes-per-chunk", &bytes_per_chunk,

--- a/src/fw_iso_rx_multiple.c
+++ b/src/fw_iso_rx_multiple.c
@@ -177,10 +177,8 @@ void hinoko_fw_iso_rx_multiple_allocate(HinokoFwIsoRxMultiple *self,
 
 	priv = hinoko_fw_iso_rx_multiple_get_instance_private(self);
 
-	hinoko_fw_iso_ctx_allocate(HINOKO_FW_ISO_CTX(self), path,
-				   HINOKO_FW_ISO_CTX_MODE_RX_MULTIPLE, 0, 0,
-				   0, exception);
-	if (*exception != NULL)
+	if (!hinoko_fw_iso_ctx_allocate(HINOKO_FW_ISO_CTX(self), path,
+					HINOKO_FW_ISO_CTX_MODE_RX_MULTIPLE, 0, 0, 0, exception))
 		return;
 
 	hinoko_fw_iso_ctx_set_rx_channels(HINOKO_FW_ISO_CTX(self),

--- a/src/fw_iso_rx_multiple.c
+++ b/src/fw_iso_rx_multiple.c
@@ -380,9 +380,9 @@ void hinoko_fw_iso_rx_multiple_stop(HinokoFwIsoRxMultiple *self)
 	hinoko_fw_iso_ctx_stop(HINOKO_FW_ISO_CTX(self));
 }
 
-void hinoko_fw_iso_rx_multiple_handle_event(HinokoFwIsoRxMultiple *self,
-				struct fw_cdev_event_iso_interrupt_mc *event,
-				GError **exception)
+gboolean hinoko_fw_iso_rx_multiple_handle_event(HinokoFwIsoRxMultiple *self,
+						struct fw_cdev_event_iso_interrupt_mc *event,
+						GError **exception)
 {
 	HinokoFwIsoRxMultiplePrivate *priv;
 	unsigned int bytes_per_chunk;
@@ -394,7 +394,7 @@ void hinoko_fw_iso_rx_multiple_handle_event(HinokoFwIsoRxMultiple *self,
 	unsigned int chunk_end;
 	struct ctx_payload *ctx_payload;
 
-	g_return_if_fail(HINOKO_IS_FW_ISO_RX_MULTIPLE(self));
+	g_return_val_if_fail(HINOKO_IS_FW_ISO_RX_MULTIPLE(self), FALSE);
 	priv = hinoko_fw_iso_rx_multiple_get_instance_private(self);
 
 	g_object_get(G_OBJECT(self),
@@ -458,11 +458,13 @@ void hinoko_fw_iso_rx_multiple_handle_event(HinokoFwIsoRxMultiple *self,
 	chunk_end = (priv->prev_offset + accum_length) / bytes_per_chunk;
 	for (; chunk_pos < chunk_end; ++chunk_pos) {
 		if (!fw_iso_rx_multiple_register_chunk(self, exception))
-			return;
+			return FALSE;
 	}
 
 	priv->prev_offset += accum_length;
 	priv->prev_offset %= bytes_per_buffer;
+
+	return TRUE;
 }
 
 /**

--- a/src/fw_iso_rx_multiple.h
+++ b/src/fw_iso_rx_multiple.h
@@ -26,28 +26,23 @@ struct _HinokoFwIsoRxMultipleClass {
 
 HinokoFwIsoRxMultiple *hinoko_fw_iso_rx_multiple_new(void);
 
-void hinoko_fw_iso_rx_multiple_allocate(HinokoFwIsoRxMultiple *self,
-					const char *path,
-					const guint8 *channels,
-					guint channels_length,
-					GError **exception);
+gboolean hinoko_fw_iso_rx_multiple_allocate(HinokoFwIsoRxMultiple *self, const char *path,
+					    const guint8 *channels, guint channels_length,
+					    GError **exception);
 void hinoko_fw_iso_rx_multiple_release(HinokoFwIsoRxMultiple *self);
 
-void hinoko_fw_iso_rx_multiple_map_buffer(HinokoFwIsoRxMultiple *self,
-					  guint bytes_per_chunk,
-					  guint chunks_per_buffer,
-					  GError **exception);
+gboolean hinoko_fw_iso_rx_multiple_map_buffer(HinokoFwIsoRxMultiple *self, guint bytes_per_chunk,
+					      guint chunks_per_buffer, GError **exception);
 void hinoko_fw_iso_rx_multiple_unmap_buffer(HinokoFwIsoRxMultiple *self);
 
-void hinoko_fw_iso_rx_multiple_start(HinokoFwIsoRxMultiple *self,
-				     const guint16 *cycle_match, guint32 sync,
-				     HinokoFwIsoCtxMatchFlag tags,
-				     guint chunks_per_irq, GError **exception);
+gboolean hinoko_fw_iso_rx_multiple_start(HinokoFwIsoRxMultiple *self, const guint16 *cycle_match,
+					 guint32 sync, HinokoFwIsoCtxMatchFlag tags,
+					 guint chunks_per_irq, GError **exception);
 void hinoko_fw_iso_rx_multiple_stop(HinokoFwIsoRxMultiple *self);
 
-void hinoko_fw_iso_rx_multiple_get_payload(HinokoFwIsoRxMultiple *self,
-					guint index, const guint8 **payload,
-					guint *length, GError **exception);
+gboolean hinoko_fw_iso_rx_multiple_get_payload(HinokoFwIsoRxMultiple *self, guint index,
+					       const guint8 **payload, guint *length,
+					       GError **exception);
 
 G_END_DECLS
 

--- a/src/fw_iso_rx_single.c
+++ b/src/fw_iso_rx_single.c
@@ -110,25 +110,29 @@ HinokoFwIsoRxSingle *hinoko_fw_iso_rx_single_new(void)
  * A local node of the node corresponding to the given path is used as the
  * controller, thus any path is accepted as long as process has enough
  * permission for the path.
+ *
+ * Returns: %TRUE if the overall operation finished successfully, otherwise %FALSE.
+ *
+ * Since: 0.7.
  */
-void hinoko_fw_iso_rx_single_allocate(HinokoFwIsoRxSingle *self,
-				      const char *path,
-				      guint channel, guint header_size,
-				      GError **exception)
+gboolean hinoko_fw_iso_rx_single_allocate(HinokoFwIsoRxSingle *self, const char *path,
+					  guint channel, guint header_size, GError **exception)
 {
 	HinokoFwIsoRxSinglePrivate *priv;
 
-	g_return_if_fail(HINOKO_IS_FW_ISO_RX_SINGLE(self));
-	g_return_if_fail(exception != NULL && *exception == NULL);
+	g_return_val_if_fail(HINOKO_IS_FW_ISO_RX_SINGLE(self), FALSE);
+	g_return_val_if_fail(exception != NULL && *exception == NULL, FALSE);
 
 	priv = hinoko_fw_iso_rx_single_get_instance_private(self);
 
 	if (!hinoko_fw_iso_ctx_allocate(HINOKO_FW_ISO_CTX(self), path,
 					HINOKO_FW_ISO_CTX_MODE_RX_SINGLE, 0, channel, header_size,
 					exception))
-		return;
+		return FALSE;
 
 	priv->header_size = header_size;
+
+	return TRUE;
 }
 
 /**
@@ -155,18 +159,20 @@ void hinoko_fw_iso_rx_single_release(HinokoFwIsoRxSingle *self)
  *
  * Map intermediate buffer to share payload of IR context with 1394 OHCI
  * controller.
+ *
+ * Returns: %TRUE if the overall operation finished successfully, otherwise %FALSE.
+ *
+ * Since: 0.7.
  */
-void hinoko_fw_iso_rx_single_map_buffer(HinokoFwIsoRxSingle *self,
-					guint maximum_bytes_per_payload,
-					guint payloads_per_buffer,
-					GError **exception)
+gboolean hinoko_fw_iso_rx_single_map_buffer(HinokoFwIsoRxSingle *self,
+					    guint maximum_bytes_per_payload,
+					    guint payloads_per_buffer, GError **exception)
 {
-	g_return_if_fail(HINOKO_IS_FW_ISO_RX_SINGLE(self));
-	g_return_if_fail(exception != NULL && *exception == NULL);
+	g_return_val_if_fail(HINOKO_IS_FW_ISO_RX_SINGLE(self), FALSE);
+	g_return_val_if_fail(exception != NULL && *exception == NULL, FALSE);
 
-	hinoko_fw_iso_ctx_map_buffer(HINOKO_FW_ISO_CTX(self),
-				     maximum_bytes_per_payload,
-				     payloads_per_buffer, exception);
+	return hinoko_fw_iso_ctx_map_buffer(HINOKO_FW_ISO_CTX(self), maximum_bytes_per_payload,
+					    payloads_per_buffer, exception);
 }
 
 /**
@@ -194,12 +200,14 @@ void hinoko_fw_iso_rx_single_unmap_buffer(HinokoFwIsoRxSingle *self)
  * hardware interrupt to generate interrupt event. In detail, please refer to documentation about
  * #HinokoFwIsoRxSingle::interrupted signal.
  *
- * Since: 0.6.
+ * Returns: %TRUE if the overall operation finished successfully, otherwise %FALSE.
+ *
+ * Since: 0.7.
  */
-void hinoko_fw_iso_rx_single_register_packet(HinokoFwIsoRxSingle *self, gboolean schedule_interrupt,
-					     GError **exception)
+gboolean hinoko_fw_iso_rx_single_register_packet(HinokoFwIsoRxSingle *self,
+						 gboolean schedule_interrupt, GError **exception)
 {
-	hinoko_fw_iso_ctx_register_chunk(HINOKO_FW_ISO_CTX(self), FALSE, 0, 0, NULL, 0, 0,
+	return hinoko_fw_iso_ctx_register_chunk(HINOKO_FW_ISO_CTX(self), FALSE, 0, 0, NULL, 0, 0,
 					 schedule_interrupt, exception);
 }
 
@@ -218,21 +226,24 @@ void hinoko_fw_iso_rx_single_register_packet(HinokoFwIsoRxSingle *self, gboolean
  *
  * Start IR context.
  *
- * Since: 0.6.
+ * Returns: %TRUE if the overall operation finished successfully, otherwise %FALSE.
+ *
+ * Since: 0.7.
  */
-void hinoko_fw_iso_rx_single_start(HinokoFwIsoRxSingle *self, const guint16 *cycle_match,
-				   guint32 sync, HinokoFwIsoCtxMatchFlag tags, GError **exception)
+gboolean hinoko_fw_iso_rx_single_start(HinokoFwIsoRxSingle *self, const guint16 *cycle_match,
+				       guint32 sync, HinokoFwIsoCtxMatchFlag tags,
+				       GError **exception)
 {
 	HinokoFwIsoRxSinglePrivate *priv;
 
-	g_return_if_fail(HINOKO_IS_FW_ISO_RX_SINGLE(self));
-	g_return_if_fail(exception != NULL && *exception == NULL);
+	g_return_val_if_fail(HINOKO_IS_FW_ISO_RX_SINGLE(self), FALSE);
+	g_return_val_if_fail(exception != NULL && *exception == NULL, FALSE);
 
 	priv = hinoko_fw_iso_rx_single_get_instance_private(self);
 
 	priv->chunk_cursor = 0;
 
-	hinoko_fw_iso_ctx_start(HINOKO_FW_ISO_CTX(self), cycle_match, sync, tags, exception);
+	return hinoko_fw_iso_ctx_start(HINOKO_FW_ISO_CTX(self), cycle_match, sync, tags, exception);
 }
 
 /**
@@ -292,10 +303,14 @@ void hinoko_fw_iso_rx_single_handle_event(HinokoFwIsoRxSingle *self,
  * @exception: A #GError.
  *
  * Retrieve payload of IR context for a handled packet corresponding to index.
+ *
+ * Returns: %TRUE if the overall operation finished successfully, otherwise %FALSE.
+ *
+ * Since: 0.7.
  */
-void hinoko_fw_iso_rx_single_get_payload(HinokoFwIsoRxSingle *self, guint index,
-					 const guint8 **payload, guint *length,
-					 GError **exception)
+gboolean hinoko_fw_iso_rx_single_get_payload(HinokoFwIsoRxSingle *self, guint index,
+					     const guint8 **payload, guint *length,
+					     GError **exception)
 {
 	HinokoFwIsoRxSinglePrivate *priv;
 	unsigned int bytes_per_chunk;
@@ -305,13 +320,13 @@ void hinoko_fw_iso_rx_single_get_payload(HinokoFwIsoRxSingle *self, guint index,
 	guint offset;
 	guint frame_size;
 
-	g_return_if_fail(HINOKO_IS_FW_ISO_RX_SINGLE(self));
-	g_return_if_fail(exception != NULL && *exception == NULL);
+	g_return_val_if_fail(HINOKO_IS_FW_ISO_RX_SINGLE(self), FALSE);
+	g_return_val_if_fail(exception != NULL && *exception == NULL, FALSE);
 
 	priv = hinoko_fw_iso_rx_single_get_instance_private(self);
 
-	g_return_if_fail(priv->ev != NULL);
-	g_return_if_fail(index * priv->header_size <= priv->ev->header_length);
+	g_return_val_if_fail(priv->ev != NULL, FALSE);
+	g_return_val_if_fail(index * priv->header_size <= priv->ev->header_length, FALSE);
 
 	g_object_get(G_OBJECT(self),
 		     "bytes-per-chunk", &bytes_per_chunk,
@@ -327,5 +342,7 @@ void hinoko_fw_iso_rx_single_get_payload(HinokoFwIsoRxSingle *self, guint index,
 	offset = index * bytes_per_chunk;
 	hinoko_fw_iso_ctx_read_frames(HINOKO_FW_ISO_CTX(self), offset, *length,
 				      payload, &frame_size);
-	g_return_if_fail(frame_size == *length);
+	g_return_val_if_fail(frame_size == *length, FALSE);
+
+	return TRUE;
 }

--- a/src/fw_iso_rx_single.c
+++ b/src/fw_iso_rx_single.c
@@ -123,10 +123,9 @@ void hinoko_fw_iso_rx_single_allocate(HinokoFwIsoRxSingle *self,
 
 	priv = hinoko_fw_iso_rx_single_get_instance_private(self);
 
-	hinoko_fw_iso_ctx_allocate(HINOKO_FW_ISO_CTX(self), path,
-				 HINOKO_FW_ISO_CTX_MODE_RX_SINGLE, 0,
-				 channel, header_size, exception);
-	if (*exception != NULL)
+	if (!hinoko_fw_iso_ctx_allocate(HINOKO_FW_ISO_CTX(self), path,
+					HINOKO_FW_ISO_CTX_MODE_RX_SINGLE, 0, channel, header_size,
+					exception))
 		return;
 
 	priv->header_size = header_size;

--- a/src/fw_iso_rx_single.c
+++ b/src/fw_iso_rx_single.c
@@ -259,16 +259,16 @@ void hinoko_fw_iso_rx_single_stop(HinokoFwIsoRxSingle *self)
 	hinoko_fw_iso_ctx_stop(HINOKO_FW_ISO_CTX(self));
 }
 
-void hinoko_fw_iso_rx_single_handle_event(HinokoFwIsoRxSingle *self,
-				struct fw_cdev_event_iso_interrupt *event,
-				GError **exception)
+gboolean hinoko_fw_iso_rx_single_handle_event(HinokoFwIsoRxSingle *self,
+					      struct fw_cdev_event_iso_interrupt *event,
+					      GError **exception)
 {
 	HinokoFwIsoRxSinglePrivate *priv;
 	guint sec;
 	guint cycle;
 	guint count;
 
-	g_return_if_fail(HINOKO_IS_FW_ISO_RX_SINGLE(self));
+	g_return_val_if_fail(HINOKO_IS_FW_ISO_RX_SINGLE(self), FALSE);
 	priv = hinoko_fw_iso_rx_single_get_instance_private(self);
 
 	sec = (event->cycle & 0x0000e000) >> 13;
@@ -291,6 +291,8 @@ void hinoko_fw_iso_rx_single_handle_event(HinokoFwIsoRxSingle *self,
 
 		priv->chunk_cursor %= chunks_per_buffer;
 	}
+
+	return TRUE;
 }
 
 /**

--- a/src/fw_iso_rx_single.h
+++ b/src/fw_iso_rx_single.h
@@ -33,28 +33,26 @@ struct _HinokoFwIsoRxSingleClass {
 
 HinokoFwIsoRxSingle *hinoko_fw_iso_rx_single_new(void);
 
-void hinoko_fw_iso_rx_single_allocate(HinokoFwIsoRxSingle *self,
-				      const char *path,
-				      guint channel, guint header_size,
-				      GError **exception);
+gboolean hinoko_fw_iso_rx_single_allocate(HinokoFwIsoRxSingle *self, const char *path,
+					  guint channel, guint header_size, GError **exception);
 void hinoko_fw_iso_rx_single_release(HinokoFwIsoRxSingle *self);
 
-void hinoko_fw_iso_rx_single_map_buffer(HinokoFwIsoRxSingle *self,
-					guint maximum_bytes_per_payload,
-					guint payloads_per_buffer,
-					GError **exception);
+gboolean hinoko_fw_iso_rx_single_map_buffer(HinokoFwIsoRxSingle *self,
+					    guint maximum_bytes_per_payload,
+					    guint payloads_per_buffer, GError **exception);
 void hinoko_fw_iso_rx_single_unmap_buffer(HinokoFwIsoRxSingle *self);
 
-void hinoko_fw_iso_rx_single_register_packet(HinokoFwIsoRxSingle *self, gboolean schedule_interrupt,
-					     GError **exception);
+gboolean hinoko_fw_iso_rx_single_register_packet(HinokoFwIsoRxSingle *self,
+						 gboolean schedule_interrupt, GError **exception);
 
-void hinoko_fw_iso_rx_single_start(HinokoFwIsoRxSingle *self, const guint16 *cycle_match,
-				   guint32 sync, HinokoFwIsoCtxMatchFlag tags, GError **exception);
+gboolean hinoko_fw_iso_rx_single_start(HinokoFwIsoRxSingle *self, const guint16 *cycle_match,
+				       guint32 sync, HinokoFwIsoCtxMatchFlag tags,
+				       GError **exception);
 void hinoko_fw_iso_rx_single_stop(HinokoFwIsoRxSingle *self);
 
-void hinoko_fw_iso_rx_single_get_payload(HinokoFwIsoRxSingle *self, guint index,
-					 const guint8 **payload, guint *length,
-					 GError **exception);
+gboolean hinoko_fw_iso_rx_single_get_payload(HinokoFwIsoRxSingle *self, guint index,
+					     const guint8 **payload, guint *length,
+					     GError **exception);
 
 G_END_DECLS
 

--- a/src/fw_iso_tx.c
+++ b/src/fw_iso_tx.c
@@ -151,9 +151,9 @@ void hinoko_fw_iso_tx_map_buffer(HinokoFwIsoTx *self,
 	g_return_if_fail(exception != NULL && *exception == NULL);
 	priv = hinoko_fw_iso_tx_get_instance_private(self);
 
-	hinoko_fw_iso_ctx_map_buffer(HINOKO_FW_ISO_CTX(self),
-				     maximum_bytes_per_payload,
-				     payloads_per_buffer, exception);
+	if (!hinoko_fw_iso_ctx_map_buffer(HINOKO_FW_ISO_CTX(self), maximum_bytes_per_payload,
+					  payloads_per_buffer, exception))
+		return;
 
 	priv->offset = 0;
 }

--- a/src/fw_iso_tx.c
+++ b/src/fw_iso_tx.c
@@ -259,10 +259,9 @@ void hinoko_fw_iso_tx_register_packet(HinokoFwIsoTx *self,
 	if (header_length == 0 && payload_length == 0)
 		skip = TRUE;
 
-	hinoko_fw_iso_ctx_register_chunk(HINOKO_FW_ISO_CTX(self), skip, tags, sy, header,
-					 header_length, payload_length, schedule_interrupt,
-					 exception);
-	if (*exception != NULL)
+	if (!hinoko_fw_iso_ctx_register_chunk(HINOKO_FW_ISO_CTX(self), skip, tags, sy, header,
+					      header_length, payload_length, schedule_interrupt,
+					      exception))
 		return;
 
 	hinoko_fw_iso_ctx_read_frames(HINOKO_FW_ISO_CTX(self), priv->offset,

--- a/src/fw_iso_tx.c
+++ b/src/fw_iso_tx.c
@@ -292,9 +292,9 @@ gboolean hinoko_fw_iso_tx_register_packet(HinokoFwIsoTx *self,HinokoFwIsoCtxMatc
 	return TRUE;
 }
 
-void hinoko_fw_iso_tx_handle_event(HinokoFwIsoTx *self,
-				   struct fw_cdev_event_iso_interrupt *event,
-				   GError **exception)
+gboolean hinoko_fw_iso_tx_handle_event(HinokoFwIsoTx *self,
+				       struct fw_cdev_event_iso_interrupt *event,
+				       GError **exception)
 {
 	guint sec = (event->cycle & 0x0000e000) >> 13;
 	guint cycle = event->cycle & 0x00001fff;
@@ -302,4 +302,6 @@ void hinoko_fw_iso_tx_handle_event(HinokoFwIsoTx *self,
 
 	g_signal_emit(self, fw_iso_tx_sigs[FW_ISO_TX_SIG_TYPE_IRQ], 0, sec, cycle, event->header,
 		      event->header_length, pkt_count);
+
+	return TRUE;
 }

--- a/src/fw_iso_tx.c
+++ b/src/fw_iso_tx.c
@@ -102,17 +102,19 @@ HinokoFwIsoTx *hinoko_fw_iso_tx_new(void)
  * Allocate an IT context to 1394 OHCI controller. A local node of the node
  * corresponding to the given path is used as the controller, thus any path is
  * accepted as long as process has enough permission for the path.
+ *
+ * Returns: %TRUE if the overall operation finished successfully, otherwise %FALSE.
+ *
+ * Since: 0.7.
  */
-void hinoko_fw_iso_tx_allocate(HinokoFwIsoTx *self, const char *path,
-			       HinokoFwScode scode, guint channel,
-			       guint header_size, GError **exception)
+gboolean hinoko_fw_iso_tx_allocate(HinokoFwIsoTx *self, const char *path, HinokoFwScode scode,
+				   guint channel, guint header_size, GError **exception)
 {
-	g_return_if_fail(HINOKO_IS_FW_ISO_TX(self));
-	g_return_if_fail(exception != NULL && *exception == NULL);
+	g_return_val_if_fail(HINOKO_IS_FW_ISO_TX(self), FALSE);
+	g_return_val_if_fail(exception != NULL && *exception == NULL, FALSE);
 
-	hinoko_fw_iso_ctx_allocate(HINOKO_FW_ISO_CTX(self), path,
-				   HINOKO_FW_ISO_CTX_MODE_TX, scode, channel,
-				   header_size, exception);
+	return hinoko_fw_iso_ctx_allocate(HINOKO_FW_ISO_CTX(self), path, HINOKO_FW_ISO_CTX_MODE_TX,
+					  scode, channel, header_size, exception);
 }
 
 /**
@@ -139,23 +141,27 @@ void hinoko_fw_iso_tx_release(HinokoFwIsoTx *self)
  *
  * Map intermediate buffer to share payload of IT context with 1394 OHCI
  * controller.
+ *
+ * Returns: %TRUE if the overall operation finished successfully, otherwise %FALSE.
+ *
+ * Since: 0.7.
  */
-void hinoko_fw_iso_tx_map_buffer(HinokoFwIsoTx *self,
-				 guint maximum_bytes_per_payload,
-				 guint payloads_per_buffer,
-				 GError **exception)
+gboolean hinoko_fw_iso_tx_map_buffer(HinokoFwIsoTx *self, guint maximum_bytes_per_payload,
+				     guint payloads_per_buffer, GError **exception)
 {
 	HinokoFwIsoTxPrivate *priv;
 
-	g_return_if_fail(HINOKO_IS_FW_ISO_TX(self));
-	g_return_if_fail(exception != NULL && *exception == NULL);
+	g_return_val_if_fail(HINOKO_IS_FW_ISO_TX(self), FALSE);
+	g_return_val_if_fail(exception != NULL && *exception == NULL, FALSE);
 	priv = hinoko_fw_iso_tx_get_instance_private(self);
 
 	if (!hinoko_fw_iso_ctx_map_buffer(HINOKO_FW_ISO_CTX(self), maximum_bytes_per_payload,
 					  payloads_per_buffer, exception))
-		return;
+		return FALSE;
 
 	priv->offset = 0;
+
+	return TRUE;
 }
 
 /**
@@ -186,14 +192,16 @@ void hinoko_fw_iso_tx_unmap_buffer(HinokoFwIsoTx *self)
  *
  * Start IT context.
  *
- * Since: 0.6.
+ * Returns: %TRUE if the overall operation finished successfully, otherwise %FALSE.
+ *
+ * Since: 0.7.
  */
-void hinoko_fw_iso_tx_start(HinokoFwIsoTx *self, const guint16 *cycle_match, GError **exception)
+gboolean hinoko_fw_iso_tx_start(HinokoFwIsoTx *self, const guint16 *cycle_match, GError **exception)
 {
-	g_return_if_fail(HINOKO_IS_FW_ISO_TX(self));
-	g_return_if_fail(exception != NULL && *exception == NULL);
+	g_return_val_if_fail(HINOKO_IS_FW_ISO_TX(self), FALSE);
+	g_return_val_if_fail(exception != NULL && *exception == NULL, FALSE);
 
-	hinoko_fw_iso_ctx_start(HINOKO_FW_ISO_CTX(self), cycle_match, 0, 0, exception);
+	return hinoko_fw_iso_ctx_start(HINOKO_FW_ISO_CTX(self), cycle_match, 0, 0, exception);
 
 }
 
@@ -233,25 +241,26 @@ void hinoko_fw_iso_tx_stop(HinokoFwIsoTx *self)
  * interrupt to generate interrupt event. In detail, please refer to documentation about
  * #HinokoFwIsoTx::interrupted.
  *
- * Since: 0.6.
+ * Returns: %TRUE if the overall operation finished successfully, otherwise %FALSE.
+ *
+ * Since: 0.7.
  */
-void hinoko_fw_iso_tx_register_packet(HinokoFwIsoTx *self,
-				HinokoFwIsoCtxMatchFlag tags, guint sy,
-				const guint8 *header, guint header_length,
-				const guint8 *payload, guint payload_length,
-				gboolean schedule_interrupt, GError **exception)
+gboolean hinoko_fw_iso_tx_register_packet(HinokoFwIsoTx *self,HinokoFwIsoCtxMatchFlag tags,
+					  guint sy, const guint8 *header, guint header_length,
+					  const guint8 *payload, guint payload_length,
+					  gboolean schedule_interrupt, GError **exception)
 {
 	HinokoFwIsoTxPrivate *priv;
 	const guint8 *frames;
 	guint frame_size;
 	gboolean skip;
 
-	g_return_if_fail(HINOKO_IS_FW_ISO_TX(self));
-	g_return_if_fail((header != NULL && header_length > 0) ||
-			 (header == NULL && header_length == 0));
-	g_return_if_fail((payload != NULL && payload_length > 0) ||
-			 (payload == NULL && payload_length == 0));
-	g_return_if_fail(exception != NULL && *exception == NULL);
+	g_return_val_if_fail(HINOKO_IS_FW_ISO_TX(self), FALSE);
+	g_return_val_if_fail((header != NULL && header_length > 0) ||
+			     (header == NULL && header_length == 0), FALSE);
+	g_return_val_if_fail((payload != NULL && payload_length > 0) ||
+			     (payload == NULL && payload_length == 0), FALSE);
+	g_return_val_if_fail(exception != NULL && *exception == NULL, FALSE);
 
 	priv = hinoko_fw_iso_tx_get_instance_private(self);
 
@@ -262,7 +271,7 @@ void hinoko_fw_iso_tx_register_packet(HinokoFwIsoTx *self,
 	if (!hinoko_fw_iso_ctx_register_chunk(HINOKO_FW_ISO_CTX(self), skip, tags, sy, header,
 					      header_length, payload_length, schedule_interrupt,
 					      exception))
-		return;
+		return FALSE;
 
 	hinoko_fw_iso_ctx_read_frames(HINOKO_FW_ISO_CTX(self), priv->offset,
 				      payload_length, &frames, &frame_size);
@@ -279,6 +288,8 @@ void hinoko_fw_iso_tx_register_packet(HinokoFwIsoTx *self,
 
 		priv->offset = frame_size;
 	}
+
+	return TRUE;
 }
 
 void hinoko_fw_iso_tx_handle_event(HinokoFwIsoTx *self,

--- a/src/fw_iso_tx.h
+++ b/src/fw_iso_tx.h
@@ -32,25 +32,22 @@ struct _HinokoFwIsoTxClass {
 
 HinokoFwIsoTx *hinoko_fw_iso_tx_new(void);
 
-void hinoko_fw_iso_tx_allocate(HinokoFwIsoTx *self, const char *path,
-			       HinokoFwScode scode, guint channel,
-			       guint header_size, GError **exception);
+gboolean hinoko_fw_iso_tx_allocate(HinokoFwIsoTx *self, const char *path, HinokoFwScode scode,
+				   guint channel, guint header_size, GError **exception);
 void hinoko_fw_iso_tx_release(HinokoFwIsoTx *self);
 
-void hinoko_fw_iso_tx_map_buffer(HinokoFwIsoTx *self,
-				 guint maximum_bytes_per_payload,
-				 guint payloads_per_buffer,
-				 GError **exception);
+gboolean hinoko_fw_iso_tx_map_buffer(HinokoFwIsoTx *self, guint maximum_bytes_per_payload,
+				     guint payloads_per_buffer, GError **exception);
 void hinoko_fw_iso_tx_unmap_buffer(HinokoFwIsoTx *self);
 
-void hinoko_fw_iso_tx_start(HinokoFwIsoTx *self, const guint16 *cycle_match, GError **exception);
+gboolean hinoko_fw_iso_tx_start(HinokoFwIsoTx *self, const guint16 *cycle_match,
+				GError **exception);
 void hinoko_fw_iso_tx_stop(HinokoFwIsoTx *self);
 
-void hinoko_fw_iso_tx_register_packet(HinokoFwIsoTx *self,
-				HinokoFwIsoCtxMatchFlag tags, guint sy,
-				const guint8 *header, guint header_length,
-				const guint8 *payload, guint payload_length,
-				gboolean schedule_interrupt, GError **exception);
+gboolean hinoko_fw_iso_tx_register_packet(HinokoFwIsoTx *self, HinokoFwIsoCtxMatchFlag tags,
+					  guint sy, const guint8 *header, guint header_length,
+					  const guint8 *payload, guint payload_length,
+					  gboolean schedule_interrupt, GError **exception);
 
 G_END_DECLS
 

--- a/src/hinoko.map
+++ b/src/hinoko.map
@@ -21,9 +21,7 @@ HINOKO_0_1_0 {
 
     "hinoko_fw_iso_tx_get_type";
     "hinoko_fw_iso_tx_new";
-    "hinoko_fw_iso_tx_allocate";
     "hinoko_fw_iso_tx_release";
-    "hinoko_fw_iso_tx_map_buffer";
     "hinoko_fw_iso_tx_unmap_buffer";
     "hinoko_fw_iso_tx_stop";
   local:
@@ -72,9 +70,6 @@ HINOKO_0_5_0 {
 } HINOKO_0_4_0;
 
 HINOKO_0_6_0 {
-  global:
-    "hinoko_fw_iso_tx_register_packet";
-    "hinoko_fw_iso_tx_start";
 } HINOKO_0_5_0;
 
 HINOKO_0_7_0 {
@@ -93,4 +88,9 @@ HINOKO_0_7_0 {
     "hinoko_fw_iso_rx_multiple_map_buffer";
     "hinoko_fw_iso_rx_multiple_start";
     "hinoko_fw_iso_rx_multiple_get_payload";
+
+    "hinoko_fw_iso_tx_allocate";
+    "hinoko_fw_iso_tx_map_buffer";
+    "hinoko_fw_iso_tx_start";
+    "hinoko_fw_iso_tx_register_packet";
 } HINOKO_0_6_0;

--- a/src/hinoko.map
+++ b/src/hinoko.map
@@ -45,10 +45,6 @@ HINOKO_0_4_0 {
 
     "hinoko_fw_iso_resource_auto_get_type";
     "hinoko_fw_iso_resource_auto_new";
-    "hinoko_fw_iso_resource_auto_allocate_async";
-    "hinoko_fw_iso_resource_auto_deallocate_async";
-    "hinoko_fw_iso_resource_auto_allocate_sync";
-    "hinoko_fw_iso_resource_auto_deallocate_sync";
 } HINOKO_0_3_0;
 
 HINOKO_0_5_0 {
@@ -94,4 +90,9 @@ HINOKO_0_7_0 {
     "hinoko_fw_iso_resource_deallocate_once_async";
     "hinoko_fw_iso_resource_allocate_once_sync";
     "hinoko_fw_iso_resource_deallocate_once_sync";
+
+    "hinoko_fw_iso_resource_auto_allocate_async";
+    "hinoko_fw_iso_resource_auto_deallocate_async";
+    "hinoko_fw_iso_resource_auto_allocate_sync";
+    "hinoko_fw_iso_resource_auto_deallocate_sync";
 } HINOKO_0_6_0;

--- a/src/hinoko.map
+++ b/src/hinoko.map
@@ -15,13 +15,9 @@ HINOKO_0_1_0 {
 
     "hinoko_fw_iso_rx_multiple_get_type";
     "hinoko_fw_iso_rx_multiple_new";
-    "hinoko_fw_iso_rx_multiple_allocate";
     "hinoko_fw_iso_rx_multiple_release";
-    "hinoko_fw_iso_rx_multiple_map_buffer";
     "hinoko_fw_iso_rx_multiple_unmap_buffer";
-    "hinoko_fw_iso_rx_multiple_start";
     "hinoko_fw_iso_rx_multiple_stop";
-    "hinoko_fw_iso_rx_multiple_get_payload";
 
     "hinoko_fw_iso_tx_get_type";
     "hinoko_fw_iso_tx_new";
@@ -92,4 +88,9 @@ HINOKO_0_7_0 {
     "hinoko_fw_iso_rx_single_register_packet";
     "hinoko_fw_iso_rx_single_start";
     "hinoko_fw_iso_rx_single_get_payload";
+
+    "hinoko_fw_iso_rx_multiple_allocate";
+    "hinoko_fw_iso_rx_multiple_map_buffer";
+    "hinoko_fw_iso_rx_multiple_start";
+    "hinoko_fw_iso_rx_multiple_get_payload";
 } HINOKO_0_6_0;

--- a/src/hinoko.map
+++ b/src/hinoko.map
@@ -8,13 +8,10 @@ HINOKO_0_1_0 {
 
     "hinoko_fw_iso_rx_single_get_type";
     "hinoko_fw_iso_rx_single_new";
-    "hinoko_fw_iso_rx_single_allocate";
     "hinoko_fw_iso_rx_single_release";
-    "hinoko_fw_iso_rx_single_map_buffer";
     "hinoko_fw_iso_rx_single_unmap_buffer";
     "hinoko_fw_iso_rx_single_stop";
     "hinoko_sigs_marshal_VOID__UINT_UINT_POINTER_UINT_UINT";
-    "hinoko_fw_iso_rx_single_get_payload";
 
     "hinoko_fw_iso_rx_multiple_get_type";
     "hinoko_fw_iso_rx_multiple_new";
@@ -82,9 +79,6 @@ HINOKO_0_6_0 {
   global:
     "hinoko_fw_iso_tx_register_packet";
     "hinoko_fw_iso_tx_start";
-
-    "hinoko_fw_iso_rx_single_register_packet";
-    "hinoko_fw_iso_rx_single_start";
 } HINOKO_0_5_0;
 
 HINOKO_0_7_0 {
@@ -92,4 +86,10 @@ HINOKO_0_7_0 {
     "hinoko_fw_iso_ctx_get_cycle_timer";
     "hinoko_fw_iso_ctx_create_source";
     "hinoko_fw_iso_ctx_flush_completions";
+
+    "hinoko_fw_iso_rx_single_allocate";
+    "hinoko_fw_iso_rx_single_map_buffer";
+    "hinoko_fw_iso_rx_single_register_packet";
+    "hinoko_fw_iso_rx_single_start";
+    "hinoko_fw_iso_rx_single_get_payload";
 } HINOKO_0_6_0;

--- a/src/hinoko.map
+++ b/src/hinoko.map
@@ -41,13 +41,7 @@ HINOKO_0_4_0 {
   global:
     "hinoko_fw_iso_resource_get_type";
     "hinoko_fw_iso_resource_new";
-    "hinoko_fw_iso_resource_open";
-    "hinoko_fw_iso_resource_create_source";
     "hinoko_fw_iso_resource_calculate_bandwidth";
-    "hinoko_fw_iso_resource_allocate_once_async";
-    "hinoko_fw_iso_resource_deallocate_once_async";
-    "hinoko_fw_iso_resource_allocate_once_sync";
-    "hinoko_fw_iso_resource_deallocate_once_sync";
 
     "hinoko_fw_iso_resource_auto_get_type";
     "hinoko_fw_iso_resource_auto_new";
@@ -93,4 +87,11 @@ HINOKO_0_7_0 {
     "hinoko_fw_iso_tx_map_buffer";
     "hinoko_fw_iso_tx_start";
     "hinoko_fw_iso_tx_register_packet";
+
+    "hinoko_fw_iso_resource_open";
+    "hinoko_fw_iso_resource_create_source";
+    "hinoko_fw_iso_resource_allocate_once_async";
+    "hinoko_fw_iso_resource_deallocate_once_async";
+    "hinoko_fw_iso_resource_allocate_once_sync";
+    "hinoko_fw_iso_resource_deallocate_once_sync";
 } HINOKO_0_6_0;

--- a/src/hinoko.map
+++ b/src/hinoko.map
@@ -5,8 +5,6 @@ HINOKO_0_1_0 {
     "hinoko_fw_iso_ctx_match_flag_get_type";
 
     "hinoko_fw_iso_ctx_get_type";
-    "hinoko_fw_iso_ctx_get_cycle_timer";
-    "hinoko_fw_iso_ctx_create_source";
 
     "hinoko_fw_iso_rx_single_get_type";
     "hinoko_fw_iso_rx_single_new";
@@ -82,11 +80,16 @@ HINOKO_0_5_0 {
 
 HINOKO_0_6_0 {
   global:
-    "hinoko_fw_iso_ctx_flush_completions";
-
     "hinoko_fw_iso_tx_register_packet";
     "hinoko_fw_iso_tx_start";
 
     "hinoko_fw_iso_rx_single_register_packet";
     "hinoko_fw_iso_rx_single_start";
 } HINOKO_0_5_0;
+
+HINOKO_0_7_0 {
+  global:
+    "hinoko_fw_iso_ctx_get_cycle_timer";
+    "hinoko_fw_iso_ctx_create_source";
+    "hinoko_fw_iso_ctx_flush_completions";
+} HINOKO_0_6_0;

--- a/src/internal.h
+++ b/src/internal.h
@@ -18,8 +18,8 @@ gboolean hinoko_fw_iso_ctx_register_chunk(HinokoFwIsoCtx *self, gboolean skip,
 					  GError **exception);
 gboolean hinoko_fw_iso_ctx_set_rx_channels(HinokoFwIsoCtx *self, guint64 *channel_flags,
 					   GError **exception);
-void hinoko_fw_iso_ctx_start(HinokoFwIsoCtx *self, const guint16 *cycle_match, guint32 sync,
-			     HinokoFwIsoCtxMatchFlag tags, GError **exception);
+gboolean hinoko_fw_iso_ctx_start(HinokoFwIsoCtx *self, const guint16 *cycle_match, guint32 sync,
+				 HinokoFwIsoCtxMatchFlag tags, GError **exception);
 void hinoko_fw_iso_ctx_stop(HinokoFwIsoCtx *self);
 void hinoko_fw_iso_ctx_read_frames(HinokoFwIsoCtx *self, guint offset,
 				   guint length, const guint8 **frames,

--- a/src/internal.h
+++ b/src/internal.h
@@ -16,9 +16,8 @@ gboolean hinoko_fw_iso_ctx_register_chunk(HinokoFwIsoCtx *self, gboolean skip,
 					  const guint8 *header, guint header_length,
 					  guint payload_length, gboolean schedule_interrupt,
 					  GError **exception);
-void hinoko_fw_iso_ctx_set_rx_channels(HinokoFwIsoCtx *self,
-				       guint64 *channel_flags,
-				       GError **exception);
+gboolean hinoko_fw_iso_ctx_set_rx_channels(HinokoFwIsoCtx *self, guint64 *channel_flags,
+					   GError **exception);
 void hinoko_fw_iso_ctx_start(HinokoFwIsoCtx *self, const guint16 *cycle_match, guint32 sync,
 			     HinokoFwIsoCtxMatchFlag tags, GError **exception);
 void hinoko_fw_iso_ctx_stop(HinokoFwIsoCtx *self);

--- a/src/internal.h
+++ b/src/internal.h
@@ -8,8 +8,8 @@ gboolean hinoko_fw_iso_ctx_allocate(HinokoFwIsoCtx *self, const char *path,
 				HinokoFwIsoCtxMode mode, HinokoFwScode scode, guint channel,
 				guint header_size, GError **exception);
 void hinoko_fw_iso_ctx_release(HinokoFwIsoCtx *self);
-void hinoko_fw_iso_ctx_map_buffer(HinokoFwIsoCtx *self, guint bytes_per_chunk,
-				  guint chunks_per_buffer, GError **exception);
+gboolean hinoko_fw_iso_ctx_map_buffer(HinokoFwIsoCtx *self, guint bytes_per_chunk,
+				      guint chunks_per_buffer, GError **exception);
 void hinoko_fw_iso_ctx_unmap_buffer(HinokoFwIsoCtx *self);
 void hinoko_fw_iso_ctx_register_chunk(HinokoFwIsoCtx *self, gboolean skip,
 				      HinokoFwIsoCtxMatchFlag tags, guint sy,

--- a/src/internal.h
+++ b/src/internal.h
@@ -37,9 +37,8 @@ gboolean hinoko_fw_iso_tx_handle_event(HinokoFwIsoTx *self,
 				       struct fw_cdev_event_iso_interrupt *event,
 				       GError **exception);
 
-void hinoko_fw_iso_resource_ioctl(HinokoFwIsoResource *self,
-				  unsigned long request, void *argp,
-				  GError **exception);
+gboolean hinoko_fw_iso_resource_ioctl(HinokoFwIsoResource *self, unsigned long request, void *argp,
+				      GError **exception);
 
 void hinoko_fw_iso_resource_auto_handle_event(HinokoFwIsoResourceAuto *self,
 					struct fw_cdev_event_iso_resource *ev);

--- a/src/internal.h
+++ b/src/internal.h
@@ -25,17 +25,17 @@ void hinoko_fw_iso_ctx_read_frames(HinokoFwIsoCtx *self, guint offset,
 				   guint length, const guint8 **frames,
 				   guint *frame_size);
 
-void hinoko_fw_iso_rx_single_handle_event(HinokoFwIsoRxSingle *self,
-				struct fw_cdev_event_iso_interrupt *event,
-				GError **exception);
+gboolean hinoko_fw_iso_rx_single_handle_event(HinokoFwIsoRxSingle *self,
+					      struct fw_cdev_event_iso_interrupt *event,
+					      GError **exception);
 
-void hinoko_fw_iso_rx_multiple_handle_event(HinokoFwIsoRxMultiple *self,
-				struct fw_cdev_event_iso_interrupt_mc *event,
-				GError **exception);
+gboolean hinoko_fw_iso_rx_multiple_handle_event(HinokoFwIsoRxMultiple *self,
+						struct fw_cdev_event_iso_interrupt_mc *event,
+						GError **exception);
 
-void hinoko_fw_iso_tx_handle_event(HinokoFwIsoTx *self,
-				   struct fw_cdev_event_iso_interrupt *event,
-				   GError **exception);
+gboolean hinoko_fw_iso_tx_handle_event(HinokoFwIsoTx *self,
+				       struct fw_cdev_event_iso_interrupt *event,
+				       GError **exception);
 
 void hinoko_fw_iso_resource_ioctl(HinokoFwIsoResource *self,
 				  unsigned long request, void *argp,

--- a/src/internal.h
+++ b/src/internal.h
@@ -4,10 +4,9 @@
 
 #include "hinoko.h"
 
-void hinoko_fw_iso_ctx_allocate(HinokoFwIsoCtx *self, const char *path,
-				HinokoFwIsoCtxMode mode, HinokoFwScode scode,
-				guint channel, guint header_size,
-				GError **exception);
+gboolean hinoko_fw_iso_ctx_allocate(HinokoFwIsoCtx *self, const char *path,
+				HinokoFwIsoCtxMode mode, HinokoFwScode scode, guint channel,
+				guint header_size, GError **exception);
 void hinoko_fw_iso_ctx_release(HinokoFwIsoCtx *self);
 void hinoko_fw_iso_ctx_map_buffer(HinokoFwIsoCtx *self, guint bytes_per_chunk,
 				  guint chunks_per_buffer, GError **exception);

--- a/src/internal.h
+++ b/src/internal.h
@@ -11,11 +11,11 @@ void hinoko_fw_iso_ctx_release(HinokoFwIsoCtx *self);
 gboolean hinoko_fw_iso_ctx_map_buffer(HinokoFwIsoCtx *self, guint bytes_per_chunk,
 				      guint chunks_per_buffer, GError **exception);
 void hinoko_fw_iso_ctx_unmap_buffer(HinokoFwIsoCtx *self);
-void hinoko_fw_iso_ctx_register_chunk(HinokoFwIsoCtx *self, gboolean skip,
-				      HinokoFwIsoCtxMatchFlag tags, guint sy,
-				      const guint8 *header, guint header_length,
-				      guint payload_length, gboolean schedule_interrupt,
-				      GError **exception);
+gboolean hinoko_fw_iso_ctx_register_chunk(HinokoFwIsoCtx *self, gboolean skip,
+					  HinokoFwIsoCtxMatchFlag tags, guint sy,
+					  const guint8 *header, guint header_length,
+					  guint payload_length, gboolean schedule_interrupt,
+					  GError **exception);
 void hinoko_fw_iso_ctx_set_rx_channels(HinokoFwIsoCtx *self,
 				       guint64 *channel_flags,
 				       GError **exception);


### PR DESCRIPTION
In GNOME convention for throw function which has an argument of GError to
report failure, the function is programmed to return value of gboolean
type to report whether the argument is filled with instance of GError. On the
other hand, I wrote the throw functions to return nothing (void).

This patchset rewrite public API according to it. Unfortunately, it brings loss of
backward compatibility.

```
Takashi Sakamoto (19):
  fw_iso_ctx: make error argument of signal as constant
  fw_iso_resource: make error argument of signal as constant
  fw_iso_resource: fix missing macro for the end of declaration
  fw_iso_resource_auto: fix missing macro for the end of declaration
  fw_iso_resource_auto: fix invalid annotation for function name
  fw_iso_ctx: rewrite internal allocation function according to GNOME convention
  fw_iso_ctx: rewrite internal mapping function according to GNOME convention
  fw_iso_ctx: rewrite internal chunk registration function according to GNOME convention
  fw_iso_ctx: rewrite internal channel indication function according to GNOME convention
  fw_iso_ctx: rewrite internal start function according to GNOME convention
  fw_iso_ctx: rewrite public API according to GNOME convention
  fw_iso_rx_single: rewrite public API according to GNOME convention
  fw_iso_rx_multiple: rewrite public API according to GNOME convention
  fw_iso_tx: rewrite public API according to GNOME convention
  fw_iso_ctx: rewrite internal event handler according to GNOME convention
  fw_iso_resource: rewrite internal API according to GNOME convention
  fw_iso_resource: rewrite public API according to GNOME convention
  fw_iso_resource_auto: rewrite public API according to GNOME convention
  update README about loss of backward compatibility at v0.7 release

 README.rst                 |  38 ++++-
 src/fw_iso_ctx.c           | 286 +++++++++++++++++++++----------------
 src/fw_iso_ctx.h           |   9 +-
 src/fw_iso_resource.c      | 169 +++++++++++++---------
 src/fw_iso_resource.h      |  48 +++----
 src/fw_iso_resource_auto.c | 103 +++++++------
 src/fw_iso_resource_auto.h |  30 ++--
 src/fw_iso_rx_multiple.c   | 127 ++++++++--------
 src/fw_iso_rx_multiple.h   |  27 ++--
 src/fw_iso_rx_single.c     | 102 +++++++------
 src/fw_iso_rx_single.h     |  28 ++--
 src/fw_iso_tx.c            |  96 +++++++------
 src/fw_iso_tx.h            |  23 ++-
 src/hinoko.map             |  56 ++++----
 src/internal.h             |  53 ++++---
 15 files changed, 676 insertions(+), 519 deletions(-)
```