### PR TITLE
[PATCH 00/15] optimization to gi-docgen

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@
 libhinoko
 =========
 
-2022/03/11
+2022/04/17
 Takashi Sakamoto
 
 Introduction
@@ -52,11 +52,10 @@ How to build
 
 ::
 
-    $ meson . build
-    $ cd build
-    $ ninja
-    $ ninja install
-    ($ ninja test)
+    $ meson (--prefix=directory-to-install) build
+    $ meson compile -C build
+    $ meson install -C build
+    ($ meson test -C build)
 
 When working with gobject-introspection, ``Hinoko-0.0.typelib`` should be installed in your system
 girepository so that ``libgirepository`` can find it. Of course, your system LD should find ELF
@@ -69,10 +68,11 @@ How to refer document
 
 ::
 
-    $ meson -Ddoc=true . build
-    $ cd build
-    $ ninja
-    $ ninja install
+    $ meson configure (--prefix=directory-to-install) -Ddoc=true build
+    $ meson compile -C build
+    $ meson install -C build
+
+You can see documentation files under ``(directory-to-install)/share/doc/hinoko/``.
 
 Loss of backward compatibility between v0.5/v0.6 releases
 =========================================================

--- a/src/cycle_timer.c
+++ b/src/cycle_timer.c
@@ -2,13 +2,11 @@
 #include "internal.h"
 
 /**
- * SECTION:cycle_timer
- * @Title: HinokoCycleTimer
- * @Short_description: A boxed object to represent data for cycle timer.
- * @include: cycle_timer.h
+ * HinokoCycleTimer:
+ * A boxed object to represent data for cycle timer.
  *
- * A #HinokoCycleTimer is an boxed object to represent the value of cycle
- * timer and timestamp referring to clock_id.
+ * A [struct@CycleTimer] is an boxed object to represent the value of cycle timer and timestamp
+ * referring to clock_id.
  */
 HinokoCycleTimer *hinoko_cycle_timer_copy(const HinokoCycleTimer *self)
 {
@@ -28,9 +26,9 @@ G_DEFINE_BOXED_TYPE(HinokoCycleTimer, hinoko_cycle_timer, hinoko_cycle_timer_cop
 /**
  * hinoko_cycle_timer_new:
  *
- * Allocate and return an instance of HinokoCycleTimer.
+ * Allocate and return an instance of [struct@CycleTimer].
  *
- * Returns: (transfer none): An instance of HinokoCycleTimer.
+ * Returns: (transfer none): An instance of [struct@CycleTimer].
  */
 HinokoCycleTimer *hinoko_cycle_timer_new()
 {
@@ -39,12 +37,12 @@ HinokoCycleTimer *hinoko_cycle_timer_new()
 
 /**
  * hinoko_cycle_timer_get_timestamp:
- * @self: A #HinokoCycleTimer.
+ * @self: A [struct@CycleTimer].
  * @tv_sec: (out): The second part of timestamp.
  * @tv_nsec: (out): The nanosecond part of timestamp.
  *
- * Get timestamp with enough sizee of strorage. The timestamp refers to
- * clock_id available by hinoko_cycle_timer_get_clock_id().
+ * Get timestamp with enough sizee of strorage. The timestamp refers to clock_id available by
+ * [method@CycleTimer.get_clock_id].
  */
 void hinoko_cycle_timer_get_timestamp(HinokoCycleTimer *self, gint64 *tv_sec,
 				      gint32 *tv_nsec)
@@ -55,10 +53,10 @@ void hinoko_cycle_timer_get_timestamp(HinokoCycleTimer *self, gint64 *tv_sec,
 
 /**
  * hinoko_cycle_timer_get_clock_id:
- * @self: A #HinokoCycleTimer.
- * @clock_id: (out): The numerical ID of clock source for the reference
- *            timestamp. One CLOCK_REALTIME(0), CLOCK_MONOTONIC(1), and
- *            CLOCK_MONOTONIC_RAW(4) is available in UAPI of Linux kernel.
+ * @self: A [struct@CycleTimer].
+ * @clock_id: (out): The numerical ID of clock source for the reference timestamp. One of
+ *	      CLOCK_REALTIME(0), CLOCK_MONOTONIC(1), and CLOCK_MONOTONIC_RAW(4) is available in
+ *	      UAPI of Linux kernel.
  *
  * Get the ID of clock for timestamp.
  */
@@ -69,10 +67,9 @@ void hinoko_cycle_timer_get_clock_id(HinokoCycleTimer *self, gint *clock_id)
 
 /**
  * hinoko_cycle_timer_get_cycle_timer:
- * @self: A #HinokoCycleTimer.
- * @cycle_timer: (array fixed-size=3)(out caller-allocates): The value of cycle
- * 		 timer register of 1394 OHCI, including three elements; second,
- * 		 cycle and offset.
+ * @self: A [struct@CycleTimer].
+ * @cycle_timer: (array fixed-size=3)(out caller-allocates): The value of cycle timer register of
+ *		 1394 OHCI, including three elements; second, cycle, and offset.
  *
  * Get the value of cycle timer in 1394 OHCI controller.
  */

--- a/src/fw_iso_ctx.c
+++ b/src/fw_iso_ctx.c
@@ -10,12 +10,10 @@
 #include <errno.h>
 
 /**
- * SECTION:fw_iso_ctx
- * @Title: HinokoFwIsoCtx
- * @Short_description: An abstract object to maintain isochronous context.
- * @include: fw_iso_ctx.h
+ * HinokoFwIsoCtx
+ * An abstract object to maintain isochronous context.
  *
- * A #HinokoFwIsoCtx is an abstract object to maintain isochronous context by
+ * A [class@FwIsoCtx] is an abstract object to maintain isochronous context by
  * UAPI of Linux FireWire subsystem. All of operations utilize ioctl(2) with
  * subsystem specific request commands. This object is designed for internal
  * use, therefore a few method and properties are available for applications.
@@ -44,9 +42,10 @@ G_DEFINE_ABSTRACT_TYPE_WITH_PRIVATE(HinokoFwIsoCtx, hinoko_fw_iso_ctx, G_TYPE_OB
 /**
  * hinoko_fw_iso_ctx_error_quark:
  *
- * Return the GQuark for error domain of GError which has code in #HinokoFwIsoCtxError.
+ * Return the [alias@GLib.Quark] for error domain of [struct@GLib.Error] which has code in
+ * Hinoko.FwIsoCtxError.
  *
- * Returns: A #GQuark.
+ * Returns: A [alias@GLib.Quark].
  */
 G_DEFINE_QUARK(hinoko-fw-iso-ctx-error-quark, hinoko_fw_iso_ctx_error)
 
@@ -164,11 +163,10 @@ static void hinoko_fw_iso_ctx_class_init(HinokoFwIsoCtxClass *klass)
 
 	/**
 	 * HinokoFwIsoCtx::stopped:
-	 * @self: A #HinokoFwIsoCtx.
-	 * @error: (nullable): A #GError.
+	 * @self: A [class@FwIsoCtx].
+	 * @error: (nullable): A [struct@GLib.Error].
 	 *
-	 * When isochronous context is stopped, #HinokoFwIsoCtx::stopped is
-	 * emitted.
+	 * Emitted when isochronous context is stopped.
 	 */
 	fw_iso_ctx_sigs[FW_ISO_CTX_SIG_TYPE_STOPPED] =
 		g_signal_new("stopped",
@@ -190,13 +188,13 @@ static void hinoko_fw_iso_ctx_init(HinokoFwIsoCtx *self)
 
 /**
  * hinoko_fw_iso_ctx_allocate:
- * @self: A #HinokoFwIsoCtx.
+ * @self: A [class@FwIsoCtx].
  * @path: A path to any Linux FireWire character device.
- * @mode: The mode of context, one of #HinokoFwIsoCtxMode enumerations.
- * @scode: The speed of context, one of #HinokoFwScode enumerations.
- * @channel: The numerical channel of context up to 64.
+ * @mode: The mode of context, one of [enum@FwIsoCtxMode] enumerations.
+ * @scode: The speed of context, one of [enum@FwScode] enumerations.
+ * @channel: The numeric channel of context up to 64.
  * @header_size: The number of bytes for header of isochronous context.
- * @error: A #GError.
+ * @error: A [struct@GLib.Error].
  *
  * Allocate a isochronous context to 1394 OHCI controller. A local node of the
  * node corresponding to the given path is used as the controller, thus any
@@ -290,7 +288,7 @@ void hinoko_fw_iso_ctx_allocate(HinokoFwIsoCtx *self, const char *path,
 
 /**
  * hinoko_fw_iso_ctx_release:
- * @self: A #HinokoFwIsoCtx.
+ * @self: A [class@FwIsoCtx].
  *
  * Release allocated isochronous context from 1394 OHCI controller.
  */
@@ -311,14 +309,12 @@ void hinoko_fw_iso_ctx_release(HinokoFwIsoCtx *self)
 
 /**
  * hinoko_fw_iso_ctx_map_buffer:
- * @self: A #HinokoFwIsoCtx.
- * @bytes_per_chunk: The number of bytes per chunk in buffer going to be
- *		     allocated.
+ * @self: A [class@FwIsoCtx].
+ * @bytes_per_chunk: The number of bytes per chunk in buffer going to be allocated.
  * @chunks_per_buffer: The number of chunks in buffer going to be allocated.
- * @error: A #GError.
+ * @error: A [struct@GLib.Error].
  *
- * Map intermediate buffer to share payload of isochronous context with 1394
- * OHCI controller.
+ * Map intermediate buffer to share payload of isochronous context with 1394 OHCI controller.
  */
 void hinoko_fw_iso_ctx_map_buffer(HinokoFwIsoCtx *self, guint bytes_per_chunk,
 				  guint chunks_per_buffer, GError **error)
@@ -370,10 +366,9 @@ void hinoko_fw_iso_ctx_map_buffer(HinokoFwIsoCtx *self, guint bytes_per_chunk,
 
 /**
  * hinoko_fw_iso_ctx_unmap_buffer:
- * @self: A #HinokoFwIsoCtx.
+ * @self: A [class@FwIsoCtx].
  *
- * Unmap intermediate buffer shard with 1394 OHCI controller for payload
- * of isochronous context.
+ * Unmap intermediate buffer shard with 1394 OHCI controller for payload of isochronous context.
  */
 void hinoko_fw_iso_ctx_unmap_buffer(HinokoFwIsoCtx *self)
 {
@@ -398,12 +393,11 @@ void hinoko_fw_iso_ctx_unmap_buffer(HinokoFwIsoCtx *self)
 
 /**
  * hinoko_fw_iso_ctx_get_cycle_timer:
- * @self: A #HinokoFwIsoCtx.
- * @clock_id: The numerical ID of clock source for the reference timestamp. One
- *            CLOCK_REALTIME(0), CLOCK_MONOTONIC(1), and CLOCK_MONOTONIC_RAW(2)
- *            is available in UAPI of Linux kernel.
- * @cycle_timer: (inout): A #HinokoCycleTimer to store data of cycle timer.
- * @error: A #GError.
+ * @self: A [class@FwIsoCtx].
+ * @clock_id: The numeric ID of clock source for the reference timestamp. One CLOCK_REALTIME(0),
+ *	      CLOCK_MONOTONIC(1), and CLOCK_MONOTONIC_RAW(2) is available in UAPI of Linux kernel.
+ * @cycle_timer: (inout): A [struct@CycleTimer] to store data of cycle timer.
+ * @error: A [struct@GLib.Error].
  *
  * Retrieve the value of cycle timer register. This method call is available
  * once any isochronous context is created.
@@ -431,9 +425,9 @@ void hinoko_fw_iso_ctx_get_cycle_timer(HinokoFwIsoCtx *self, gint clock_id,
 
 /**
  * hinoko_fw_iso_ctx_set_rx_channels:
- * @self: A #HinokoFwIsoCtx.
+ * @self: A [class@FwIsoCtx].
  * @channel_flags: Flags for channels to listen to.
- * @error: A #GError.
+ * @error: A [struct@GLib.Error].
  *
  * Indicate channels to listen to for IR context in buffer-fill mode.
  */
@@ -467,16 +461,16 @@ void hinoko_fw_iso_ctx_set_rx_channels(HinokoFwIsoCtx *self,
 
 /**
  * hinoko_fw_iso_ctx_register_chunk:
- * @self: A #HinokoFwIsoCtx.
+ * @self: A [class@FwIsoCtx].
  * @skip: Whether to skip packet transmission or not.
  * @tags: The value of tag field for isochronous packet to handle.
  * @sy: The value of sy field for isochronous packet to handle.
- * @header: (array length=header_length) (element-type guint8): The content of
- * 	    header for IT context, nothing for IR context.
+ * @header: (array length=header_length) (element-type guint8): The content of header for IT
+ *	    context, nothing for IR context.
  * @header_length: The number of bytes for @header.
  * @payload_length: The number of bytes for payload of isochronous context.
  * @schedule_interrupt: schedule hardware interrupt at isochronous cycle for the chunk.
- * @error: A #GError.
+ * @error: A [struct@GLib.Error].
  *
  * Register data on buffer for payload of isochronous context.
  */
@@ -791,11 +785,12 @@ static void finalize_src(GSource *gsrc)
 
 /**
  * hinoko_fw_iso_ctx_create_source:
- * @self: A #hinokoFwIsoCtx.
- * @gsrc: (out): A #GSource.
- * @error: A #GError.
+ * @self: A [class@FwIsoCtx].
+ * @gsrc: (out): A [struct@GLib.Source].
+ * @error: A [struct@GLib.Error].
  *
- * Create Gsource for GMainContext to dispatch events for isochronous context.
+ * Create [struct@GLib.Source] for [struct@GLib.MainContext] to dispatch events for isochronous
+ * context.
  */
 void hinoko_fw_iso_ctx_create_source(HinokoFwIsoCtx *self, GSource **gsrc,
 				     GError **error)
@@ -844,16 +839,14 @@ void hinoko_fw_iso_ctx_create_source(HinokoFwIsoCtx *self, GSource **gsrc,
 
 /**
  * hinoko_fw_iso_ctx_start:
- * @self: A #HinokoFwIsoCtx.
- * @cycle_match: (array fixed-size=2) (element-type guint16) (in) (nullable):
- * 		 The isochronous cycle to start packet processing. The first
- * 		 element should be the second part of isochronous cycle, up to
- * 		 3. The second element should be the cycle part of isochronous
- * 		 cycle, up to 7999.
- * @sync: The value of sync field in isochronous header for packet processing,
- * 	  up to 15.
+ * @self: A [class@FwIsoCtx].
+ * @cycle_match: (array fixed-size=2) (element-type guint16) (in) (nullable): The isochronous cycle
+ *		 to start packet processing. The first element should be the second part of
+ *		 isochronous cycle, up to 3. The second element should be the cycle part of
+ *		 isochronous cycle, up to 7999.
+ * @sync: The value of sync field in isochronous header for packet processing, up to 15.
  * @tags: The value of tag field in isochronous header for packet processing.
- * @error: A #GError.
+ * @error: A [struct@GLib.Error].
  *
  * Start isochronous context.
  */
@@ -922,7 +915,7 @@ void hinoko_fw_iso_ctx_start(HinokoFwIsoCtx *self, const guint16 *cycle_match, g
 
 /**
  * hinoko_fw_iso_ctx_stop:
- * @self: A #HinokoFwIsoCtx.
+ * @self: A [class@FwIsoCtx].
  *
  * Stop isochronous context.
  */
@@ -935,11 +928,11 @@ void hinoko_fw_iso_ctx_stop(HinokoFwIsoCtx *self)
 
 /**
  * hinoko_fw_iso_ctx_read_frames:
- * @self: A #HinokoFwIsoCtx.
+ * @self: A [class@FwIsoCtx].
  * @offset: offset from head of buffer.
  * @length: the number of bytes to read.
- * @frames: (array length=frame_size)(out)(transfer none)(nullable): The array
- * 	    to fill the same data frame as @frame_size.
+ * @frames: (array length=frame_size)(out)(transfer none)(nullable): The array to fill the same
+ *	    data frame as @frame_size.
  * @frame_size: this value is for a case to truncate due to the end of buffer.
  *
  * Read frames to given buffer.
@@ -971,8 +964,8 @@ void hinoko_fw_iso_ctx_read_frames(HinokoFwIsoCtx *self, guint offset,
 
 /**
  * hinoko_fw_iso_ctx_flush_completions:
- * @self: A #HinokoFwIsoCtx.
- * @error: A #GError.
+ * @self: A [class@FwIsoCtx].
+ * @error: A [struct@GLib.Error].
  *
  * Flush isochronous context until recent isochronous cycle. The call of function forces the
  * context to queue any type of interrupt event for the recent isochronous cycle. Application can

--- a/src/fw_iso_ctx.h
+++ b/src/fw_iso_ctx.h
@@ -31,12 +31,12 @@ struct _HinokoFwIsoCtxClass {
 
 void hinoko_fw_iso_ctx_get_cycle_timer(HinokoFwIsoCtx *self, gint clock_id,
 				       HinokoCycleTimer *const *cycle_timer,
-				       GError **exception);
+				       GError **error);
 
 void hinoko_fw_iso_ctx_create_source(HinokoFwIsoCtx *self, GSource **gsrc,
-				     GError **exception);
+				     GError **error);
 
-void hinoko_fw_iso_ctx_flush_completions(HinokoFwIsoCtx *self, GError **exception);
+void hinoko_fw_iso_ctx_flush_completions(HinokoFwIsoCtx *self, GError **error);
 
 G_END_DECLS
 

--- a/src/fw_iso_ctx.h
+++ b/src/fw_iso_ctx.h
@@ -19,11 +19,10 @@ struct _HinokoFwIsoCtxClass {
 
 	/**
 	 * HinokoFwIsoCtxClass::stopped:
-	 * @self: A #HinokoFwIsoCtx.
-	 * @error: (nullable): A #GError.
+	 * @self: A [class@FwIsoCtx].
+	 * @error: (nullable): A [struct@GLib.Error].
 	 *
-	 * When isochronous context is stopped, #HinokoFwIsoCtxClass::stopped
-	 * handler is called. When any error occurs, it's reported.
+	 * Class closure for the [signal@FwIsoCtx::stopped] signal.
 	 */
 	void (*stopped)(HinokoFwIsoCtx *self, const GError *error);
 };

--- a/src/fw_iso_resource.c
+++ b/src/fw_iso_resource.c
@@ -9,15 +9,12 @@
 #include <sys/ioctl.h>
 
 /**
- * SECTION:fw_iso_resource
- * @Title: HinokoFwIsoResource
- * @Short_description: An object to initiate requests and listen events of
- *		       isochronous resource allocation/deallocation.
- * @include: fw_iso_resource.h
+ * HinokoFwIsoResource:
+ * An object to initiate requests and listen events of isochronous resource allocation/deallocation.
  *
- * A #HinokoFwIsoResource is an object to initiate requests and listen events
- * of isochronous resource allocation/deallocation by file descriptor owned
- * internally. This object is designed to be used for any derived object.
+ * A [class@FwIsoResource] is an object to initiate requests and listen events of isochronous
+ * resource allocation/deallocation by file descriptor owned internally. This object is designed to
+ * be used for any derived object.
  */
 typedef struct {
 	int fd;
@@ -27,9 +24,10 @@ G_DEFINE_TYPE_WITH_PRIVATE(HinokoFwIsoResource, hinoko_fw_iso_resource, G_TYPE_O
 /**
  * hinoko_fw_iso_resource_error_quark:
  *
- * Return the GQuark for error domain of GError which has code in #HinokoFwIsoResourceError.
+ * Return the [alias@GLib.Quark] for error domain of [struct@GLib.Error] which has code in
+ * Hinoko.FwIsoResourceError.
  *
- * Returns: A #GQuark.
+ * Returns: A [alias@GLib.Quark].
  */
 G_DEFINE_QUARK(hinoko-fw-iso-resource-error-quark, hinoko_fw_iso_resource_error)
 
@@ -93,15 +91,13 @@ static void hinoko_fw_iso_resource_class_init(HinokoFwIsoResourceClass *klass)
 
 	/**
 	 * HinokoFwIsoResource::allocated:
-	 * @self: A #HinokoFwIsoResource.
+	 * @self: A [class@FwIsoResource].
 	 * @channel: The deallocated channel number.
 	 * @bandwidth: The deallocated amount of bandwidth.
-	 * @error: A #GError. Error can be generated with domain of
-	 *	   #hinoko_fw_iso_resource_error_quark() and code of
-	 *	   #HINOKO_FW_ISO_RESOURCE_ERROR_EVENT.
+	 * @error: A [struct@GLib.Error]. Error can be generated with domain of
+	 *	   Hinoko.FwIsoResourceError and its EVENT code.
 	 *
-	 * When allocation of isochronous resource finishes, the #HinokoFwIsoResource::allocated
-	 * handler is called to notify the result, channel, and bandwidth.
+	 * Emitted when allocation of isochronous resource finishes.
 	 */
 	fw_iso_resource_sigs[FW_ISO_RESOURCE_SIG_ALLOCATED] =
 		g_signal_new("allocated",
@@ -115,15 +111,13 @@ static void hinoko_fw_iso_resource_class_init(HinokoFwIsoResourceClass *klass)
 
 	/**
 	 * HinokoFwIsoResource::deallocated:
-	 * @self: A #HinokoFwIsoResource.
+	 * @self: A [class@FwIsoResource].
 	 * @channel: The deallocated channel number.
 	 * @bandwidth: The deallocated amount of bandwidth.
-	 * @error: A #GError. Error can be generated with domain of
-	 *	   #hinoko_fw_iso_resource_error_quark() and code of
-	 *	   #HINOKO_FW_ISO_RESOURCE_ERROR_EVENT.
+	 * @error: A [struct@GLib.Error]. Error can be generated with domain of
+	 *	   Hinoko.FwIsoResourceError and its EVENT code.
 	 *
-	 * When deallocation of isochronous resource finishes, the #HinokoFwIsoResource::deallocated
-	 * handler is called to notify the result, channel, and bandwidth.
+	 * Emitted when deallocation of isochronous resource finishes.
 	 */
 	fw_iso_resource_sigs[FW_ISO_RESOURCE_SIG_DEALLOCATED] =
 		g_signal_new("deallocated",
@@ -146,9 +140,9 @@ static void hinoko_fw_iso_resource_init(HinokoFwIsoResource *self)
 /**
  * hinoko_fw_iso_resource_new:
  *
- * Allocate and return an instance of #HinokoFwIsoResource.
+ * Allocate and return an instance of [class@FwIsoResource].
  *
- * Returns: A #HinokoFwIsoResource.
+ * Returns: A [class@FwIsoResource].
  */
 HinokoFwIsoResource *hinoko_fw_iso_resource_new()
 {
@@ -157,12 +151,12 @@ HinokoFwIsoResource *hinoko_fw_iso_resource_new()
 
 /**
  * hinoko_fw_iso_resource_open:
- * @self: A #HinokoFwIsoResource.
+ * @self: A [class@FwIsoResource].
  * @path: A path of any Linux FireWire character device.
  * @open_flag: The flag of open(2) system call. O_RDONLY is forced to fulfil
  *	       internally.
- * @error: A #GError. Error can be generated with two domains; g_file_error_quark(),
- *	       and #hinoko_fw_iso_resource_error_quark().
+ * @error: A [struct@GLib.Error]. Error can be generated with two domains; GLib.FileError
+ *	   and Hinoko.FwIsoResourceError.
  *
  * Open Linux FireWire character device to delegate any request for isochronous
  * resource management to Linux FireWire subsystem.
@@ -195,17 +189,16 @@ void hinoko_fw_iso_resource_open(HinokoFwIsoResource *self, const gchar *path,
 
 /**
  * hinoko_fw_iso_resource_allocate_once_async:
- * @self: A #HinokoFwIsoResource.
+ * @self: A [class@FwIsoResource].
  * @channel_candidates: (array length=channel_candidates_count): The array with
  *			elements for numerical number for isochronous channel
  *			to be allocated.
  * @channel_candidates_count: The number of channel candidates.
  * @bandwidth: The amount of bandwidth to be allocated.
- * @error: A #GError. Error can be generated with domain of
- *	       #hinoko_fw_iso_resource_error_quark().
+ * @error: A [struct@GLib.Error]. Error can be generated with domain of Hinoko.FwIsoResourceError.
  *
  * Initiate allocation of isochronous resource without any wait. When the
- * allocation finishes, #HinokoFwIsoResource::allocated signal is emit to notify the result,
+ * allocation finishes, [signal@FwIsoResource::allocated] signal is emit to notify the result,
  * channel, and bandwidth.
  */
 void hinoko_fw_iso_resource_allocate_once_async(HinokoFwIsoResource *self,
@@ -243,14 +236,13 @@ void hinoko_fw_iso_resource_allocate_once_async(HinokoFwIsoResource *self,
 
 /**
  * hinoko_fw_iso_resource_deallocate_once_async:
- * @self: A #HinokoFwIsoResource.
+ * @self: A [class@FwIsoResource].
  * @channel: The channel number to be deallocated.
  * @bandwidth: The amount of bandwidth to be deallocated.
- * @error: A #GError. Error can be generated with domain of
- *	       #hinoko_fw_iso_resource_error_quark().
+ * @error: A [struct@GLib.Error]. Error can be generated with domain of Hinoko.FwIsoResourceError.
  *
  * Initiate deallocation of isochronous resource without any wait. When the
- * deallocation finishes, #HinokoFwIsoResource::deallocated signal is emit to notify the result,
+ * deallocation finishes, [signal@FwIsoResource::deallocated] signal is emit to notify the result,
  * channel, and bandwidth.
  */
 void hinoko_fw_iso_resource_deallocate_once_async(HinokoFwIsoResource *self,
@@ -303,16 +295,16 @@ static void handle_event_signal(HinokoFwIsoResource *self, guint channel,
 
 /**
  * hinoko_fw_iso_resource_allocate_once_sync:
- * @self: A #HinokoFwIsoResource.
+ * @self: A [class@FwIsoResource].
  * @channel_candidates: (array length=channel_candidates_count): The array with
  *			elements for numerical number for isochronous channel
  *			to be allocated.
  * @channel_candidates_count: The number of channel candidates.
  * @bandwidth: The amount of bandwidth to be allocated.
- * @error: A #GError. Error can be generated with domain of
- *	       #hinoko_fw_iso_resource_error_quark().
+ * @error: A [struct@GLib.Error]. Error can be generated with domain of Hinoko.FwIsoResourceError.
  *
- * Initiate allocation of isochronous resource and wait for #HinokoFwIsoResource::allocated signal.
+ * Initiate allocation of isochronous resource and wait for [signal@FwIsoResource::allocated]
+ * signal.
  */
 void hinoko_fw_iso_resource_allocate_once_sync(HinokoFwIsoResource *self,
 					       guint8 *channel_candidates,
@@ -362,14 +354,13 @@ void hinoko_fw_iso_resource_allocate_once_sync(HinokoFwIsoResource *self,
 
 /**
  * hinoko_fw_iso_resource_deallocate_once_sync:
- * @self: A #HinokoFwIsoResource.
+ * @self: A [class@FwIsoResource].
  * @channel: The channel number to be deallocated.
  * @bandwidth: The amount of bandwidth to be deallocated.
- * @error: A #GError. Error can be generated with domain of
- *	       #hinoko_fw_iso_resource_error_quark().
+ * @error: A [struct@GLib.Error]. Error can be generated with domain of Hinoko.FwIsoResourceError.
  *
  * Initiate deallocation of isochronous resource. When the deallocation is done,
- * #HinokoFwIsoResource::deallocated signal is emit to notify the result, channel, and bandwidth.
+ * [signal@FwIsoResource::deallocated] signal is emit to notify the result, channel, and bandwidth.
  */
 void hinoko_fw_iso_resource_deallocate_once_sync(HinokoFwIsoResource *self,
 						 guint channel,
@@ -556,11 +547,12 @@ static void finalize_src(GSource *gsrc)
 
 /**
  * hinoko_fw_iso_resource_create_source:
- * @self: A #hinokoFwIsoResource.
- * @gsrc: (out): A #GSource.
- * @error: A #GError.
+ * @self: A [class@FwIsoResource].
+ * @gsrc: (out): A [struct@GLib.Source]
+ * @error: A [struct@GLib.Error].
  *
- * Create Gsource for GMainContext to dispatch events for isochronous resource.
+ * Create [struct@GLib.Source] for [struct@GLib.MainContext] to dispatch events for isochronous
+ * resource.
  */
 void hinoko_fw_iso_resource_create_source(HinokoFwIsoResource *self,
 					  GSource **gsrc, GError **error)

--- a/src/fw_iso_resource.h
+++ b/src/fw_iso_resource.h
@@ -20,30 +20,26 @@ struct _HinokoFwIsoResourceClass {
 
 	/**
 	 * HinokoFwIsoResourceClass::allocated:
-	 * @self: A #HinokoFwIsoResource.
+	 * @self: A [class@FwIsoResource].
 	 * @channel: The deallocated channel number.
 	 * @bandwidth: The deallocated amount of bandwidth.
-	 * @error: A #GError. Error can be generated with domain of
-	 *	   #hinoko_fw_iso_resource_error_quark() and code of
-	 *	   #HINOKO_FW_ISO_RESOURCE_ERROR_EVENT.
+	 * @error: A [struct@GLib.Error]. Error can be generated with domain of
+	 *	   Hinoko.FwIsoResourceError and its EVENT code.
 	 *
-	 * When allocation of isochronous resource finishes, the #HinokoFwIsoResourceClass::allocated
-	 * handler is called to notify the result, channel, and bandwidth.
+	 * Class closure for the [signal@FwIsoResource::allocated] signal.
 	 */
 	void (*allocated)(HinokoFwIsoResource *self, guint channel,
 			  guint bandwidth, const GError *error);
 
 	/**
 	 * HinokoFwIsoResourceClass::deallocated:
-	 * @self: A #HinokoFwIsoResource.
+	 * @self: A [class@FwIsoResource].
 	 * @channel: The deallocated channel number.
 	 * @bandwidth: The deallocated amount of bandwidth.
-	 * @error: A #GError. Error can be generated with domain of
-	 *	   #hinoko_fw_iso_resource_error_quark() and code of
-	 *	   #HINOKO_FW_ISO_RESOURCE_ERROR_EVENT.
+	 * @error: A [struct@GLib.Error]. Error can be generated with domain of
+	 *	   Hinoko.FwIsoResourceError and its EVENT code.
 	 *
-	 * When deallocation of isochronous resource finishes, the #HinokoFwIsoResourceClass::deallocated
-	 * handler is called to notify the result, channel, and bandwidth.
+	 * Class closure for the [signal@FwIsoResource::deallocated] signal.
 	 */
 	void (*deallocated)(HinokoFwIsoResource *self, guint channel,
 			    guint bandwidth, const GError *error);

--- a/src/fw_iso_resource.h
+++ b/src/fw_iso_resource.h
@@ -52,10 +52,10 @@ struct _HinokoFwIsoResourceClass {
 HinokoFwIsoResource *hinoko_fw_iso_resource_new();
 
 void hinoko_fw_iso_resource_open(HinokoFwIsoResource *self, const gchar *path,
-				 gint open_flag, GError **exception);
+				 gint open_flag, GError **error);
 
 void hinoko_fw_iso_resource_create_source(HinokoFwIsoResource *self,
-					  GSource **gsrc, GError **exception);
+					  GSource **gsrc, GError **error);
 
 guint hinoko_fw_iso_resource_calculate_bandwidth(guint bytes_per_payload,
 						 HinokoFwScode scode);
@@ -64,23 +64,23 @@ void hinoko_fw_iso_resource_allocate_once_async(HinokoFwIsoResource *self,
 						guint8 *channel_candidates,
 						gsize channel_candidates_count,
 						guint bandwidth,
-						GError **exception);
+						GError **error);
 
 void hinoko_fw_iso_resource_deallocate_once_async(HinokoFwIsoResource *self,
 						  guint channel,
 						  guint bandwidth,
-						  GError **exception);
+						  GError **error);
 
 void hinoko_fw_iso_resource_allocate_once_sync(HinokoFwIsoResource *self,
 					       guint8 *channel_candidates,
 					       gsize channel_candidates_count,
 					       guint bandwidth,
-					       GError **exception);
+					       GError **error);
 
 void hinoko_fw_iso_resource_deallocate_once_sync(HinokoFwIsoResource *self,
 						 guint channel,
 						 guint bandwidth,
-						 GError **exception);
+						 GError **error);
 
 G_END_DECLS
 

--- a/src/fw_iso_resource_auto.c
+++ b/src/fw_iso_resource_auto.c
@@ -4,15 +4,12 @@
 #include <errno.h>
 
 /**
- * SECTION:fw_iso_resource_auto
- * @Title: HinokoFwIsoResourceAuto
- * @Short_description: An object to maintain allocated isochronous resource.
- * @include: fw_iso_resource_auto.h
+ * HinokoFwIsoResourceAuto:
+ * An object to maintain allocated isochronous resource.
  *
- * A #HinokoFwIsoResourceAuto is an object to maintain isochronous resource
- * during the lifetime of the object. The allocated isochronous resource is
- * kept even if the generation of the bus updates. The maintenance of allocated
- * isochronous resource is done by Linux FireWire subsystem.
+ * A [class@FwIsoResourceAuto]is an object to maintain isochronous resource during the lifetime of
+ * the object. The allocated isochronous resource is kept even if the generation of the bus
+ * updates. The maintenance of allocated isochronous resource is done by Linux FireWire subsystem.
  */
 typedef struct {
 	gboolean allocated;
@@ -28,9 +25,10 @@ G_DEFINE_TYPE_WITH_PRIVATE(HinokoFwIsoResourceAuto, hinoko_fw_iso_resource_auto,
 /**
  * hinoko_fw_iso_resource_auto_error_quark:
  *
- * Return the GQuark for error domain of GError which has code in #HinokoFwIsoResourceAutoError.
+ * Return the [alias@GLib.Quark] for error domain of [struct@GLib.Error] which has code in
+ * Hinoko.FwIsoResourceAutoError.
  *
- * Returns: A #GQuark.
+ * Returns: A [alias@GLib.Quark].
  */
 G_DEFINE_QUARK(hinoko-fw-iso-resource-auto-error-quark, hinoko_fw_iso_resource_auto_error)
 
@@ -120,9 +118,9 @@ static void hinoko_fw_iso_resource_auto_init(HinokoFwIsoResourceAuto *self)
 /**
  * hinoko_fw_iso_resource_auto_new:
  *
- * Allocate and return an instance of #HinokoFwIsoResourceAuto object.
+ * Allocate and return an instance of [class@FwIsoResourceAuto]object.
  *
- * Returns: A #HinokoFwIsoResourceAuto.
+ * Returns: A [class@FwIsoResourceAuto]
  */
 HinokoFwIsoResourceAuto *hinoko_fw_iso_resource_auto_new()
 {
@@ -131,17 +129,17 @@ HinokoFwIsoResourceAuto *hinoko_fw_iso_resource_auto_new()
 
 /**
  * hinoko_fw_iso_resource_auto_allocate_async:
- * @self: A #HinokoFwIsoResourceAuto.
+ * @self: A [class@FwIsoResourceAuto]
  * @channel_candidates: (array length=channel_candidates_count): The array with
  *			elements for numerical number for isochronous channel
  *			to be allocated.
  * @channel_candidates_count: The number of channel candidates.
  * @bandwidth: The amount of bandwidth to be allocated.
- * @error: A #GError. Error can be generated with domain of
- *	       #hinoko_fw_iso_resource_error_quark(), and #hinoko_fw_iso_resource_auto_error_quark().
+ * @error: A [struct@GLib.Error]. Error can be generated with domain of
+ *	   Hinoko.FwIsoResourceError and Hinoko.FwIsoResourceAutoError.
  *
  * Initiate allocation of isochronous resource. When the allocation is done,
- * #HinokoFwIsoResource::allocated signal is emit to notify the result, channel, and bandwidth.
+ * [signal@FwIsoResource::allocated] signal is emit to notify the result, channel, and bandwidth.
  */
 void hinoko_fw_iso_resource_auto_allocate_async(HinokoFwIsoResourceAuto *self,
 						guint8 *channel_candidates,
@@ -186,12 +184,12 @@ end:
 
 /**
  * hinoko_fw_iso_resource_auto_deallocate_async:
- * @self: A #HinokoFwIsoResourceAuto.
- * @error: A #GError. Error can be generated with domain of
- *	       #hinoko_fw_iso_resource_error_quark(), and #hinoko_fw_iso_resource_auto_error_quark().
+ * @self: A [class@FwIsoResourceAuto]
+ * @error: A [struct@GLib.Error]. Error can be generated with domain of
+ *	   Hinoko.FwIsoResourceError, and Hinoko.FwIsoResourceAutoError.
  *
  * Initiate deallocation of isochronous resource. When the deallocation is done,
- * #HinokoFwIsoResource::deallocated signal is emit to notify the result, channel, and bandwidth.
+ * [signal@FwIsoResource::deallocated] signal is emit to notify the result, channel, and bandwidth.
  */
 void hinoko_fw_iso_resource_auto_deallocate_async(HinokoFwIsoResourceAuto *self,
 						  GError **error)
@@ -243,18 +241,17 @@ static void handle_event_signal(HinokoFwIsoResourceAuto *self, guint channel,
 
 /**
  * hinoko_fw_iso_resource_auto_allocate_sync:
- * @self: A #HinokoFwIsoResourceAuto.
- * @channel_candidates: (array length=channel_candidates_count): The array with
- *			elements for numerical number for isochronous channel
- *			to be allocated.
+ * @self: A [class@FwIsoResourceAuto]
+ * @channel_candidates: (array length=channel_candidates_count): The array with elements for
+ *			numerical number for isochronous channel to be allocated.
  * @channel_candidates_count: The number of channel candidates.
  * @bandwidth: The amount of bandwidth to be allocated.
- * @error: A #GError. Error can be generated with domain of
- *	       #hinoko_fw_iso_resource_error_quark(), and #hinoko_fw_iso_resource_auto_error_quark().
+ * @error: A [struct@GLib.Error]. Error can be generated with domain of
+ *	   Hinoko.FwIsoResourceError, and Hinoko.FwIsoResourceAutoError.
  *
- * Initiate allocation of isochronous resource and wait for #HinokoFwIsoResource::allocated signal.
- * When the call is successful, #HinokoFwIsoResourceAuto:channel and #HinokoFwIsoResourceAuto:bandwidth
- * properties are available.
+ * Initiate allocation of isochronous resource and wait for [signal@FwIsoResource::allocated]
+ * signal. When the call is successful, [property@FwIsoResourceAuto:channel] and
+ * [property@FwIsoResourceAuto:bandwidth] properties are available.
  */
 void hinoko_fw_iso_resource_auto_allocate_sync(HinokoFwIsoResourceAuto *self,
 					       guint8 *channel_candidates,
@@ -304,12 +301,12 @@ void hinoko_fw_iso_resource_auto_allocate_sync(HinokoFwIsoResourceAuto *self,
 
 /**
  * hinoko_fw_iso_resource_auto_deallocate_sync:
- * @self: A #HinokoFwIsoResourceAuto.
- * @error: A #GError. Error can be generated with domain of
- *	       #hinoko_fw_iso_resource_error_quark(), and #hinoko_fw_iso_resource_auto_error_quark().
+ * @self: A [class@FwIsoResourceAuto]
+ * @error: A [struct@GLib.Error]. Error can be generated with domain of
+ *	   Hinoko.FwIsoResourceError, and Hinoko.FwIsoResourceAutoError.
  *
  * Initiate deallocation of isochronous resource. When the deallocation is done,
- * #HinokoFwIsoResource::deallocated signal is emit to notify the result, channel, and bandwidth.
+ * [signal@FwIsoResource::deallocated] signal is emit to notify the result, channel, and bandwidth.
  */
 void hinoko_fw_iso_resource_auto_deallocate_sync(HinokoFwIsoResourceAuto *self,
 						 GError **error)

--- a/src/fw_iso_resource_auto.h
+++ b/src/fw_iso_resource_auto.h
@@ -25,17 +25,17 @@ void hinoko_fw_iso_resource_auto_allocate_async(HinokoFwIsoResourceAuto *self,
 						guint8 *channel_candidates,
 						gsize channel_candidates_count,
 						guint bandwidth,
-						GError **exception);
+						GError **error);
 void hinoko_fw_iso_resource_auto_allocate_sync(HinokoFwIsoResourceAuto *self,
 					       guint8 *channel_candidates,
 					       gsize channel_candidates_count,
 					       guint bandwidth,
-					       GError **exception);
+					       GError **error);
 
 void hinoko_fw_iso_resource_auto_deallocate_async(HinokoFwIsoResourceAuto *self,
-						  GError **exception);
+						  GError **error);
 void hinoko_fw_iso_resource_auto_deallocate_sync(HinokoFwIsoResourceAuto *self,
-						 GError **exception);
+						 GError **error);
 
 G_END_DECLS
 

--- a/src/fw_iso_rx_multiple.c
+++ b/src/fw_iso_rx_multiple.c
@@ -4,14 +4,11 @@
 #include <errno.h>
 
 /**
- * SECTION:fw_iso_rx_multiple
- * @Title: HinokoFwIsoRxMultiple
- * @Short_description: An object to receive isochronous packet for several
- *		       channels.
- * @include: fw_iso_rx_multiple.h
+ * HinokoFwIsoRxMultiple:
+ * An object to receive isochronous packet for several channels.
  *
- * A #HinokoFwIsoRxMultiple receives isochronous packets for several channels by
- * IR context for buffer-fill mode in 1394 OHCI.
+ * A [class@FwIsoRxMultiple] receives isochronous packets for several channels by IR context for
+ * buffer-fill mode in 1394 OHCI.
  */
 struct ctx_payload {
 	unsigned int offset;
@@ -96,19 +93,18 @@ static void hinoko_fw_iso_rx_multiple_class_init(HinokoFwIsoRxMultipleClass *kla
 
 	/**
 	 * HinokoFwIsoRxMultiple::interrupted:
-	 * @self: A #HinokoFwIsoRxMultiple.
+	 * @self: A [class@FwIsoRxMultiple].
 	 * @count: The number of packets available in this interrupt.
 	 *
-	 * When Linux FireWire subsystem generates interrupt event, the
-	 * #HinokoFwIsoRxMultiple::interrupted signal is emitted. There are two cases for Linux
-	 * FireWire subsystem to generate the event:
+	 * Emitted when Linux FireWire subsystem generates interrupt event. There are two cases
+	 * for Linux FireWire subsystem to generate the event:
 	 *
 	 * - When OHCI 1394 controller generates hardware interrupt as a result to process the
 	 *   isochronous packet for the buffer chunk marked to generate hardware interrupt.
-	 * - When application calls #hinoko_fw_iso_ctx_flush_completions() explicitly.
+	 * - When application calls [method@FwIsoCtx.flush_completions] explicitly.
 	 *
 	 * The handler of signal can retrieve the content of packet by call of
-	 * #hinoko_fw_iso_rx_multiple_get_payload().
+	 * [method@FwIsoRxMultiple.get_payload].
 	 */
 	fw_iso_rx_multiple_sigs[FW_ISO_RX_MULTIPLE_SIG_TYPE_IRQ] =
 		g_signal_new("interrupted",
@@ -129,9 +125,9 @@ static void hinoko_fw_iso_rx_multiple_init(HinokoFwIsoRxMultiple *self)
 /**
  * hinoko_fw_iso_rx_multiple_new:
  *
- * Instantiate #HinokoFwIsoRxMultiple object and return the instance.
+ * Instantiate [class@FwIsoRxMultiple] object and return the instance.
  *
- * Returns: an instance of #HinokoFwIsoRxMultiple.
+ * Returns: an instance of [class@FwIsoRxMultiple].
  */
 HinokoFwIsoRxMultiple *hinoko_fw_iso_rx_multiple_new(void)
 {
@@ -140,17 +136,16 @@ HinokoFwIsoRxMultiple *hinoko_fw_iso_rx_multiple_new(void)
 
 /**
  * hinoko_fw_iso_rx_multiple_allocate:
- * @self: A #HinokoFwIsoRxMultiple.
+ * @self: A [class@FwIsoRxMultiple].
  * @path: A path to any Linux FireWire character device.
- * @channels: (array length=channels_length) (element-type guint8): an array
- *	      for channels to listen to.
- * @channels_length: The length of @channels.
- * @error: A #GError.
+ * @channels: (array length=channels_length) (element-type guint8): an array for channels to listen
+ *	      to.
+ * @channels_length: The length of channels.
+ * @error: A [struct@GLib.Error].
  *
- * Allocate an IR context to 1394 OHCI controller for buffer-fill mode.
- * A local node of the node corresponding to the given path is used as the
- * controller, thus any path is accepted as long as process has enough
- * permission for the path.
+ * Allocate an IR context to 1394 OHCI controller for buffer-fill mode. A local node of the node
+ * corresponding to the given path is used as the controller, thus any path is accepted as long as
+ * process has enough permission for the path.
  */
 void hinoko_fw_iso_rx_multiple_allocate(HinokoFwIsoRxMultiple *self,
 					const char *path,
@@ -205,7 +200,7 @@ void hinoko_fw_iso_rx_multiple_allocate(HinokoFwIsoRxMultiple *self,
 
 /**
  * hinoko_fw_iso_rx_multiple_release:
- * @self: A #HinokoFwIsoRxMultiple.
+ * @self: A [class@FwIsoRxMultiple].
  *
  * Release allocated IR context from 1394 OHCI controller.
  */
@@ -227,11 +222,11 @@ void hinoko_fw_iso_rx_multiple_release(HinokoFwIsoRxMultiple *self)
 
 /**
  * hinoko_fw_iso_rx_multiple_map_buffer:
- * @self: A #HinokoFwIsoRxMultiple.
- * @bytes_per_chunk: The maximum number of bytes for payload of isochronous
- *		     packet (not payload for isochronous context).
+ * @self: A [class@FwIsoRxMultiple].
+ * @bytes_per_chunk: The maximum number of bytes for payload of isochronous packet (not payload for
+ *		     isochronous context).
  * @chunks_per_buffer: The number of chunks in buffer.
- * @error: A #GError.
+ * @error: A [struct@GLib.Error].
  *
  * Map an intermediate buffer to share payload of IR context with 1394 OHCI
  * controller.
@@ -274,10 +269,9 @@ void hinoko_fw_iso_rx_multiple_map_buffer(HinokoFwIsoRxMultiple *self,
 
 /**
  * hinoko_fw_iso_rx_multiple_unmap_buffer:
- * @self: A #HinokoFwIsoRxMultiple.
+ * @self: A [class@FwIsoRxMultiple].
  *
- * Unmap intermediate buffer shard with 1394 OHCI controller for payload
- * of IR context.
+ * Unmap intermediate buffer shard with 1394 OHCI controller for payload of IR context.
  */
 void hinoko_fw_iso_rx_multiple_unmap_buffer(HinokoFwIsoRxMultiple *self)
 {
@@ -315,19 +309,17 @@ static void fw_iso_rx_multiple_register_chunk(HinokoFwIsoRxMultiple *self,
 
 /**
  * hinoko_fw_iso_rx_multiple_start:
- * @self: A #HinokoFwIsoRxMultiple.
- * @cycle_match: (array fixed-size=2) (element-type guint16) (in) (nullable):
- * 		 The isochronous cycle to start packet processing. The first
- * 		 element should be the second part of isochronous cycle, up to
- * 		 3. The second element should be the cycle part of isochronous
- * 		 cycle, up to 7999.
- * @sync: The value of sync field in isochronous header for packet processing,
- * 	  up to 15.
+ * @self: A [class@FwIsoRxMultiple].
+ * @cycle_match: (array fixed-size=2) (element-type guint16) (in) (nullable): The isochronous cycle
+ *		 to start packet processing. The first element should be the second part of
+ *		 isochronous cycle, up to 3. The second element should be the cycle part of
+ *		 isochronous cycle, up to 7999.
+ * @sync: The value of sync field in isochronous header for packet processing, up to 15.
  * @tags: The value of tag field in isochronous header for packet processing.
  * @chunks_per_irq: The number of chunks per interval of interrupt. When 0 is given, application
- *		    should call #hinoko_fw_iso_ctx_flush_completions voluntarily to generate
- *		    #HinokoFwIsoRxMultiple::interrupted event.
- * @error: A #GError.
+ *		    should call [method@FwIsoCtx.flush_completions] voluntarily to generate
+ *		    [signal@FwIsoRxMultiple::interrupted] event.
+ * @error: A [struct@GLib.Error]
  *
  * Start IR context.
  */
@@ -363,7 +355,7 @@ void hinoko_fw_iso_rx_multiple_start(HinokoFwIsoRxMultiple *self,
 
 /**
  * hinoko_fw_iso_rx_multiple_stop:
- * @self: A #HinokoFwIsoRxMultiple.
+ * @self: A [class@FwIsoRxMultiple].
  *
  * Stop IR context.
  */
@@ -462,12 +454,12 @@ void hinoko_fw_iso_rx_multiple_handle_event(HinokoFwIsoRxMultiple *self,
 
 /**
  * hinoko_fw_iso_rx_multiple_get_payload:
- * @self: A #HinokoFwIsoRxMultiple.
+ * @self: A [class@FwIsoRxMultiple].
  * @index: the index of packet available in this interrupt.
- * @payload: (array length=length)(out)(transfer none): The array with data
- * 	     frame for payload of IR context.
+ * @payload: (array length=length)(out)(transfer none): The array with data frame for payload of
+ *	     IR context.
  * @length: The number of bytes in the above @payload.
- * @error: A #GError.
+ * @error: A [struct@GLib.Error].
  */
 void hinoko_fw_iso_rx_multiple_get_payload(HinokoFwIsoRxMultiple *self,
 					guint index, const guint8 **payload,

--- a/src/fw_iso_rx_multiple.h
+++ b/src/fw_iso_rx_multiple.h
@@ -30,24 +30,24 @@ void hinoko_fw_iso_rx_multiple_allocate(HinokoFwIsoRxMultiple *self,
 					const char *path,
 					const guint8 *channels,
 					guint channels_length,
-					GError **exception);
+					GError **error);
 void hinoko_fw_iso_rx_multiple_release(HinokoFwIsoRxMultiple *self);
 
 void hinoko_fw_iso_rx_multiple_map_buffer(HinokoFwIsoRxMultiple *self,
 					  guint bytes_per_chunk,
 					  guint chunks_per_buffer,
-					  GError **exception);
+					  GError **error);
 void hinoko_fw_iso_rx_multiple_unmap_buffer(HinokoFwIsoRxMultiple *self);
 
 void hinoko_fw_iso_rx_multiple_start(HinokoFwIsoRxMultiple *self,
 				     const guint16 *cycle_match, guint32 sync,
 				     HinokoFwIsoCtxMatchFlag tags,
-				     guint chunks_per_irq, GError **exception);
+				     guint chunks_per_irq, GError **error);
 void hinoko_fw_iso_rx_multiple_stop(HinokoFwIsoRxMultiple *self);
 
 void hinoko_fw_iso_rx_multiple_get_payload(HinokoFwIsoRxMultiple *self,
 					guint index, const guint8 **payload,
-					guint *length, GError **exception);
+					guint *length, GError **error);
 
 G_END_DECLS
 

--- a/src/fw_iso_rx_multiple.h
+++ b/src/fw_iso_rx_multiple.h
@@ -16,10 +16,10 @@ struct _HinokoFwIsoRxMultipleClass {
 
 	/**
 	 * HinokoFwIsoRxMultipleClass::interrupted:
-	 * @self: A #HinokoFwIsoRxMultiple.
+	 * @self: A [class@FwIsoRxMultiple].
 	 * @count: The number of packets available in this interrupt.
 	 *
-	 * In detail, please refer to documentation about #HinokoFwIsoRxMultiple::interrupted.
+	 * Class closure for the [signal@FwIsoRxMultiple::interrupted].
 	 */
 	void (*interrupted)(HinokoFwIsoRxMultiple *self, guint count);
 };

--- a/src/fw_iso_rx_single.c
+++ b/src/fw_iso_rx_single.c
@@ -104,7 +104,7 @@ HinokoFwIsoRxSingle *hinoko_fw_iso_rx_single_new(void)
  * @path: A path to any Linux FireWire character device.
  * @channel: An isochronous channel to listen.
  * @header_size: The number of bytes for header of IR context.
- * @exception: A #GError.
+ * @error: A #GError.
  *
  * Allocate an IR context to 1394 OHCI controller for packet-per-buffer mode.
  * A local node of the node corresponding to the given path is used as the
@@ -114,19 +114,19 @@ HinokoFwIsoRxSingle *hinoko_fw_iso_rx_single_new(void)
 void hinoko_fw_iso_rx_single_allocate(HinokoFwIsoRxSingle *self,
 				      const char *path,
 				      guint channel, guint header_size,
-				      GError **exception)
+				      GError **error)
 {
 	HinokoFwIsoRxSinglePrivate *priv;
 
 	g_return_if_fail(HINOKO_IS_FW_ISO_RX_SINGLE(self));
-	g_return_if_fail(exception != NULL && *exception == NULL);
+	g_return_if_fail(error != NULL && *error == NULL);
 
 	priv = hinoko_fw_iso_rx_single_get_instance_private(self);
 
 	hinoko_fw_iso_ctx_allocate(HINOKO_FW_ISO_CTX(self), path,
 				 HINOKO_FW_ISO_CTX_MODE_RX_SINGLE, 0,
-				 channel, header_size, exception);
-	if (*exception != NULL)
+				 channel, header_size, error);
+	if (*error != NULL)
 		return;
 
 	priv->header_size = header_size;
@@ -152,7 +152,7 @@ void hinoko_fw_iso_rx_single_release(HinokoFwIsoRxSingle *self)
  * @maximum_bytes_per_payload: The maximum number of bytes per payload of IR
  *			       context.
  * @payloads_per_buffer: The number of payload in buffer.
- * @exception: A #GError.
+ * @error: A #GError.
  *
  * Map intermediate buffer to share payload of IR context with 1394 OHCI
  * controller.
@@ -160,14 +160,14 @@ void hinoko_fw_iso_rx_single_release(HinokoFwIsoRxSingle *self)
 void hinoko_fw_iso_rx_single_map_buffer(HinokoFwIsoRxSingle *self,
 					guint maximum_bytes_per_payload,
 					guint payloads_per_buffer,
-					GError **exception)
+					GError **error)
 {
 	g_return_if_fail(HINOKO_IS_FW_ISO_RX_SINGLE(self));
-	g_return_if_fail(exception != NULL && *exception == NULL);
+	g_return_if_fail(error != NULL && *error == NULL);
 
 	hinoko_fw_iso_ctx_map_buffer(HINOKO_FW_ISO_CTX(self),
 				     maximum_bytes_per_payload,
-				     payloads_per_buffer, exception);
+				     payloads_per_buffer, error);
 }
 
 /**
@@ -189,7 +189,7 @@ void hinoko_fw_iso_rx_single_unmap_buffer(HinokoFwIsoRxSingle *self)
  * hinoko_fw_iso_rx_single_register_packet:
  * @self: A #HinokoFwIsoRxSingle.
  * @schedule_interrupt: Whether to schedule hardware interrupt at isochronous cycle for the packet.
- * @exception: A #GError.
+ * @error: A #GError.
  *
  * Register chunk of buffer to process packet for future isochronous cycle. The caller can schedule
  * hardware interrupt to generate interrupt event. In detail, please refer to documentation about
@@ -198,10 +198,10 @@ void hinoko_fw_iso_rx_single_unmap_buffer(HinokoFwIsoRxSingle *self)
  * Since: 0.6.
  */
 void hinoko_fw_iso_rx_single_register_packet(HinokoFwIsoRxSingle *self, gboolean schedule_interrupt,
-					     GError **exception)
+					     GError **error)
 {
 	hinoko_fw_iso_ctx_register_chunk(HINOKO_FW_ISO_CTX(self), FALSE, 0, 0, NULL, 0, 0,
-					 schedule_interrupt, exception);
+					 schedule_interrupt, error);
 }
 
 /**
@@ -215,25 +215,25 @@ void hinoko_fw_iso_rx_single_register_packet(HinokoFwIsoRxSingle *self, gboolean
  * @sync: The value of sync field in isochronous header for packet processing,
  * 	  up to 15.
  * @tags: The value of tag field in isochronous header for packet processing.
- * @exception: A #GError.
+ * @error: A #GError.
  *
  * Start IR context.
  *
  * Since: 0.6.
  */
 void hinoko_fw_iso_rx_single_start(HinokoFwIsoRxSingle *self, const guint16 *cycle_match,
-				   guint32 sync, HinokoFwIsoCtxMatchFlag tags, GError **exception)
+				   guint32 sync, HinokoFwIsoCtxMatchFlag tags, GError **error)
 {
 	HinokoFwIsoRxSinglePrivate *priv;
 
 	g_return_if_fail(HINOKO_IS_FW_ISO_RX_SINGLE(self));
-	g_return_if_fail(exception != NULL && *exception == NULL);
+	g_return_if_fail(error != NULL && *error == NULL);
 
 	priv = hinoko_fw_iso_rx_single_get_instance_private(self);
 
 	priv->chunk_cursor = 0;
 
-	hinoko_fw_iso_ctx_start(HINOKO_FW_ISO_CTX(self), cycle_match, sync, tags, exception);
+	hinoko_fw_iso_ctx_start(HINOKO_FW_ISO_CTX(self), cycle_match, sync, tags, error);
 }
 
 /**
@@ -251,7 +251,7 @@ void hinoko_fw_iso_rx_single_stop(HinokoFwIsoRxSingle *self)
 
 void hinoko_fw_iso_rx_single_handle_event(HinokoFwIsoRxSingle *self,
 				struct fw_cdev_event_iso_interrupt *event,
-				GError **exception)
+				GError **error)
 {
 	HinokoFwIsoRxSinglePrivate *priv;
 	guint sec;
@@ -290,13 +290,13 @@ void hinoko_fw_iso_rx_single_handle_event(HinokoFwIsoRxSingle *self,
  * @payload: (element-type guint8)(array length=length)(out)(transfer none): The
  *	     array with data frame for payload of IR context.
  * @length: The number of bytes in the above @payload.
- * @exception: A #GError.
+ * @error: A #GError.
  *
  * Retrieve payload of IR context for a handled packet corresponding to index.
  */
 void hinoko_fw_iso_rx_single_get_payload(HinokoFwIsoRxSingle *self, guint index,
 					 const guint8 **payload, guint *length,
-					 GError **exception)
+					 GError **error)
 {
 	HinokoFwIsoRxSinglePrivate *priv;
 	unsigned int bytes_per_chunk;
@@ -307,7 +307,7 @@ void hinoko_fw_iso_rx_single_get_payload(HinokoFwIsoRxSingle *self, guint index,
 	guint frame_size;
 
 	g_return_if_fail(HINOKO_IS_FW_ISO_RX_SINGLE(self));
-	g_return_if_fail(exception != NULL && *exception == NULL);
+	g_return_if_fail(error != NULL && *error == NULL);
 
 	priv = hinoko_fw_iso_rx_single_get_instance_private(self);
 

--- a/src/fw_iso_rx_single.c
+++ b/src/fw_iso_rx_single.c
@@ -5,13 +5,10 @@
 #include <errno.h>
 
 /**
- * SECTION:fw_iso_rx_single
- * @Title: HinokoFwIsoRxSingle
- * @Short_description: An object to receive isochronous packet for single
- *		       channel.
- * @include: fw_iso_rx_single.h
+ * HinokoFwIsoRxSingle:
+ * An object to receive isochronous packet for single channel.
  *
- * A #HinokoFwIsoRxSingle receives isochronous packets for single channel by IR
+ * A [class@FwIsoRxSingle] receives isochronous packets for single channel by IR
  * context for packet-per-buffer mode in 1394 OHCI. The content of packet is
  * split to two parts; context header and context payload in a manner of Linux
  * FireWire subsystem.
@@ -48,26 +45,25 @@ static void hinoko_fw_iso_rx_single_class_init(HinokoFwIsoRxSingleClass *klass)
 
 	/**
 	 * HinokoFwIsoRxSingle::interrupted:
-	 * @self: A #HinokoFwIsoRxSingle.
+	 * @self: A [class@FwIsoRxSingle]
 	 * @sec: sec part of isochronous cycle when interrupt occurs.
 	 * @cycle: cycle part of of isochronous cycle when interrupt occurs.
-	 * @header: (array length=header_length) (element-type guint8): The
-	 * 	    headers of IR context for handled packets.
+	 * @header: (array length=header_length) (element-type guint8): The headers of IR context
+	 *	    for handled packets.
 	 * @header_length: the number of bytes for @header.
 	 * @count: the number of packets to handle.
 	 *
-	 * When Linux FireWire subsystem generates interrupt event, the
-	 * #HinokoFwIsoRxSingle::interrupted signal is emitted. There are three cases for Linux
-	 * FireWire subsystem to generate the event:
+	 * Emitted when Linux FireWire subsystem generates interrupt event. There are three cases
+	 * for Linux FireWire subsystem to generate the event:
 	 *
 	 * - When OHCI 1394 controller generates hardware interrupt as a result to process the
 	 *   isochronous packet for the buffer chunk marked to generate hardware interrupt.
 	 * - When the size of accumulated context header for packets since the last event reaches
 	 *   the size of memory page (usually 4,096 bytes).
-	 * - When application calls #hinoko_fw_iso_ctx_flush_completions() explicitly.
+	 * - When application calls [method@FwIsoCtx.flush_completions] explicitly.
 	 *
 	 * The handler of signal can retrieve context payload of received packet by call of
-	 * #hinoko_fw_iso_rx_single_get_payload().
+	 * [method@FwIsoRxSingle.get_payload].
 	 */
 	fw_iso_rx_single_sigs[FW_ISO_RX_SINGLE_SIG_TYPE_IRQ] =
 		g_signal_new("interrupted",
@@ -89,9 +85,9 @@ static void hinoko_fw_iso_rx_single_init(HinokoFwIsoRxSingle *self)
 /**
  * hinoko_fw_iso_rx_single_new:
  *
- * Instantiate #HinokoFwIsoRxSingle object and return the instance.
+ * Instantiate [class@FwIsoRxSingle] object and return the instance.
  *
- * Returns: an instance of #HinokoFwIsoRxSingle.
+ * Returns: an instance of [class@FwIsoRxSingle].
  */
 HinokoFwIsoRxSingle *hinoko_fw_iso_rx_single_new(void)
 {
@@ -100,16 +96,15 @@ HinokoFwIsoRxSingle *hinoko_fw_iso_rx_single_new(void)
 
 /**
  * hinoko_fw_iso_rx_single_allocate:
- * @self: A #HinokoFwIsoRxSingle.
+ * @self: A [class@FwIsoRxSingle].
  * @path: A path to any Linux FireWire character device.
  * @channel: An isochronous channel to listen.
  * @header_size: The number of bytes for header of IR context.
- * @error: A #GError.
+ * @error: A [struct@GLib.Error].
  *
- * Allocate an IR context to 1394 OHCI controller for packet-per-buffer mode.
- * A local node of the node corresponding to the given path is used as the
- * controller, thus any path is accepted as long as process has enough
- * permission for the path.
+ * Allocate an IR context to 1394 OHCI controller for packet-per-buffer mode. A local node of the
+ * node corresponding to the given path is used as the controller, thus any path is accepted as
+ * long as process has enough permission for the path.
  */
 void hinoko_fw_iso_rx_single_allocate(HinokoFwIsoRxSingle *self,
 				      const char *path,
@@ -134,7 +129,7 @@ void hinoko_fw_iso_rx_single_allocate(HinokoFwIsoRxSingle *self,
 
 /**
  * hinoko_fw_iso_rx_single_release:
- * @self: A #HinokoFwIsoRxSingle.
+ * @self: A [class@FwIsoRxSingle].
  *
  * Release allocated IR context from 1394 OHCI controller.
  */
@@ -148,14 +143,12 @@ void hinoko_fw_iso_rx_single_release(HinokoFwIsoRxSingle *self)
 
 /*
  * hinoko_fw_iso_rx_single_map_buffer:
- * @self: A #HinokoFwIsoRxSingle.
- * @maximum_bytes_per_payload: The maximum number of bytes per payload of IR
- *			       context.
+ * @self: A [class@FwIsoRxSingle].
+ * @maximum_bytes_per_payload: The maximum number of bytes per payload of IR context.
  * @payloads_per_buffer: The number of payload in buffer.
- * @error: A #GError.
+ * @error: A [struct@GLib.Error].
  *
- * Map intermediate buffer to share payload of IR context with 1394 OHCI
- * controller.
+ * Map intermediate buffer to share payload of IR context with 1394 OHCI controller.
  */
 void hinoko_fw_iso_rx_single_map_buffer(HinokoFwIsoRxSingle *self,
 					guint maximum_bytes_per_payload,
@@ -172,10 +165,9 @@ void hinoko_fw_iso_rx_single_map_buffer(HinokoFwIsoRxSingle *self,
 
 /**
  * hinoko_fw_iso_rx_single_unmap_buffer:
- * @self: A #HinokoFwIsoRxSingle.
+ * @self: A [class@FwIsoRxSingle].
  *
- * Unmap intermediate buffer shard with 1394 OHCI controller for payload
- * of IR context.
+ * Unmap intermediate buffer shard with 1394 OHCI controller for payload of IR context.
  */
 void hinoko_fw_iso_rx_single_unmap_buffer(HinokoFwIsoRxSingle *self)
 {
@@ -187,13 +179,13 @@ void hinoko_fw_iso_rx_single_unmap_buffer(HinokoFwIsoRxSingle *self)
 
 /**
  * hinoko_fw_iso_rx_single_register_packet:
- * @self: A #HinokoFwIsoRxSingle.
+ * @self: A [class@FwIsoRxSingle].
  * @schedule_interrupt: Whether to schedule hardware interrupt at isochronous cycle for the packet.
- * @error: A #GError.
+ * @error: A [struct@GLib.Error].
  *
  * Register chunk of buffer to process packet for future isochronous cycle. The caller can schedule
  * hardware interrupt to generate interrupt event. In detail, please refer to documentation about
- * #HinokoFwIsoRxSingle::interrupted signal.
+ * [signal@FwIsoRxSingle::interrupted] signal.
  *
  * Since: 0.6.
  */
@@ -206,16 +198,14 @@ void hinoko_fw_iso_rx_single_register_packet(HinokoFwIsoRxSingle *self, gboolean
 
 /**
  * hinoko_fw_iso_rx_single_start:
- * @self: A #HinokoFwIsoRxSingle.
- * @cycle_match: (array fixed-size=2) (element-type guint16) (in) (nullable):
- * 		 The isochronous cycle to start packet processing. The first
- * 		 element should be the second part of isochronous cycle, up to
- * 		 3. The second element should be the cycle part of isochronous
- * 		 cycle, up to 7999.
- * @sync: The value of sync field in isochronous header for packet processing,
- * 	  up to 15.
+ * @self: A [class@FwIsoRxSingle].
+ * @cycle_match: (array fixed-size=2) (element-type guint16) (in) (nullable): The isochronous cycle
+ *		 to start packet processing. The first element should be the second part of
+ *		 isochronous cycle, up to 3. The second element should be the cycle part of
+ *		 isochronous cycle, up to 7999.
+ * @sync: The value of sync field in isochronous header for packet processing, up to 15.
  * @tags: The value of tag field in isochronous header for packet processing.
- * @error: A #GError.
+ * @error: A [struct@GLib.Error].
  *
  * Start IR context.
  *
@@ -238,7 +228,7 @@ void hinoko_fw_iso_rx_single_start(HinokoFwIsoRxSingle *self, const guint16 *cyc
 
 /**
  * hinoko_fw_iso_rx_single_stop:
- * @self: A #HinokoFwIsoRxSingle.
+ * @self: A [class@FwIsoRxSingle].
  *
  * Stop IR context.
  */
@@ -285,12 +275,12 @@ void hinoko_fw_iso_rx_single_handle_event(HinokoFwIsoRxSingle *self,
 
 /**
  * hinoko_fw_iso_rx_single_get_payload:
- * @self: A #HinokoFwIsoRxSingle.
+ * @self: A [class@FwIsoRxSingle].
  * @index: the index inner available packets.
- * @payload: (element-type guint8)(array length=length)(out)(transfer none): The
- *	     array with data frame for payload of IR context.
- * @length: The number of bytes in the above @payload.
- * @error: A #GError.
+ * @payload: (element-type guint8)(array length=length)(out)(transfer none): The array with data
+ *	     frame for payload of IR context.
+ * @length: The number of bytes in the above payload.
+ * @error: A [struct@GLib.Error].
  *
  * Retrieve payload of IR context for a handled packet corresponding to index.
  */

--- a/src/fw_iso_rx_single.h
+++ b/src/fw_iso_rx_single.h
@@ -16,15 +16,15 @@ struct _HinokoFwIsoRxSingleClass {
 
 	/**
 	 * HinokoFwIsoRxSingleClass::interrupted:
-	 * @self: A #HinokoFwIsoRxSingle.
+	 * @self: A [class@FwIsoRxSingle].
 	 * @sec: sec part of isochronous cycle when interrupt occurs.
 	 * @cycle: cycle part of of isochronous cycle when interrupt occurs.
-	 * @header: (array length=header_length) (element-type guint8): The
-	 * 	    headers of IR context for handled packets.
-	 * @header_length: the number of bytes for @header.
+	 * @header: (array length=header_length) (element-type guint8): The headers of IR context
+	 *	    for handled packets.
+	 * @header_length: the number of bytes for header.
 	 * @count: the number of packets to handle.
 	 *
-	 * In detail, please refer to documentation about #HinokoFwIsoRxSingle::interrupted.
+	 * Class closure for the [signal@FwIsoRxSingle::interrupted] signal.
 	 */
 	void (*interrupted)(HinokoFwIsoRxSingle *self, guint sec, guint cycle,
 			    const guint8 *header, guint header_length,

--- a/src/fw_iso_rx_single.h
+++ b/src/fw_iso_rx_single.h
@@ -36,25 +36,25 @@ HinokoFwIsoRxSingle *hinoko_fw_iso_rx_single_new(void);
 void hinoko_fw_iso_rx_single_allocate(HinokoFwIsoRxSingle *self,
 				      const char *path,
 				      guint channel, guint header_size,
-				      GError **exception);
+				      GError **error);
 void hinoko_fw_iso_rx_single_release(HinokoFwIsoRxSingle *self);
 
 void hinoko_fw_iso_rx_single_map_buffer(HinokoFwIsoRxSingle *self,
 					guint maximum_bytes_per_payload,
 					guint payloads_per_buffer,
-					GError **exception);
+					GError **error);
 void hinoko_fw_iso_rx_single_unmap_buffer(HinokoFwIsoRxSingle *self);
 
 void hinoko_fw_iso_rx_single_register_packet(HinokoFwIsoRxSingle *self, gboolean schedule_interrupt,
-					     GError **exception);
+					     GError **error);
 
 void hinoko_fw_iso_rx_single_start(HinokoFwIsoRxSingle *self, const guint16 *cycle_match,
-				   guint32 sync, HinokoFwIsoCtxMatchFlag tags, GError **exception);
+				   guint32 sync, HinokoFwIsoCtxMatchFlag tags, GError **error);
 void hinoko_fw_iso_rx_single_stop(HinokoFwIsoRxSingle *self);
 
 void hinoko_fw_iso_rx_single_get_payload(HinokoFwIsoRxSingle *self, guint index,
 					 const guint8 **payload, guint *length,
-					 GError **exception);
+					 GError **error);
 
 G_END_DECLS
 

--- a/src/fw_iso_tx.c
+++ b/src/fw_iso_tx.c
@@ -5,15 +5,12 @@
 #include <errno.h>
 
 /**
- * SECTION:fw_iso_tx
- * @Title: HinokoFwIsoTx
- * @Short_description: An object to transmit isochronous packet for single
- *		       channel.
- * @include: fw_iso_tx.h
+ * HinokoFwIsoTx:
+ * An object to transmit isochronous packet for single channel.
  *
- * A #HinokoFwIsoTx transmits isochronous packets for single channel by IT
- * context in 1394 OHCI. The content of packet is split to two parts; context
- * header and context payload in a manner of Linux FireWire subsystem.
+ * A [class@FwIsoTx] transmits isochronous packets for single channel by IT context in 1394 OHCI.
+ * The content of packet is split to two parts; context header and context payload in a manner of
+ * Linux FireWire subsystem.
  */
 typedef struct {
 	guint offset;
@@ -43,23 +40,22 @@ static void hinoko_fw_iso_tx_class_init(HinokoFwIsoTxClass *klass)
 
 	/**
 	 * HinokoFwIsoTx::interrupted:
-	 * @self: A #HinokoFwIsoTx.
+	 * @self: A [class@FwIsoTx].
 	 * @sec: sec part of isochronous cycle when interrupt occurs.
 	 * @cycle: cycle part of of isochronous cycle when interrupt occurs.
-	 * @tstamp: (array length=tstamp_length) (element-type guint8): A series
-	 *	    of timestamps for packets already handled.
+	 * @tstamp: (array length=tstamp_length) (element-type guint8): A series of timestamps for
+	 *	    packets already handled.
 	 * @tstamp_length: the number of bytes for @tstamp.
 	 * @count: the number of handled packets.
 	 *
-	 * When Linux FireWire subsystem generates interrupt event, the #HinokoFwIsoTx::interrupted
-	 * signal is emitted. There are three cases for Linux FireWire subsystem to generate the
-	 * event:
+	 * Emitted when Linux FireWire subsystem generates interrupt event. There are three cases
+	 * for Linux FireWire subsystem to generate the event:
 	 *
 	 * - When OHCI 1394 controller generates hardware interrupt as a result of processing the
 	 *   isochronous packet for the buffer chunk marked to generate hardware interrupt.
 	 * - When the number of isochronous packets sent since the last interrupt event reaches
 	 *   one quarter of memory page size (usually 4,096 / 4 = 1,024 packets).
-	 * - When application calls #hinoko_fw_iso_ctx_flush_completions() explicitly.
+	 * - When application calls [method@FwIsoCtx.flush_completions] explicitly.
 	 */
 	fw_iso_tx_sigs[FW_ISO_TX_SIG_TYPE_IRQ] =
 		g_signal_new("interrupted",
@@ -81,9 +77,9 @@ static void hinoko_fw_iso_tx_init(HinokoFwIsoTx *self)
 /**
  * hinoko_fw_iso_tx_new:
  *
- * Instantiate #HinokoFwIsoTx object and return the instance.
+ * Instantiate [class@FwIsoTx] object and return the instance.
  *
- * Returns: an instance of #HinokoFwIsoTx.
+ * Returns: an instance of [class@FwIsoTx].
  */
 HinokoFwIsoTx *hinoko_fw_iso_tx_new(void)
 {
@@ -92,16 +88,16 @@ HinokoFwIsoTx *hinoko_fw_iso_tx_new(void)
 
 /**
  * hinoko_fw_iso_tx_allocate:
- * @self: A #HinokoFwIsoTx.
+ * @self: A [class@FwIsoTx].
  * @path: A path to any Linux FireWire character device.
- * @scode: A #HinokoFwScode to indicate speed of isochronous communication.
+ * @scode: A [enum@FwScode] to indicate speed of isochronous communication.
  * @channel: An isochronous channel to transfer.
  * @header_size: The number of bytes for header of IT context.
- * @error: A #GError.
+ * @error: A [struct@GLib.Error].
  *
- * Allocate an IT context to 1394 OHCI controller. A local node of the node
- * corresponding to the given path is used as the controller, thus any path is
- * accepted as long as process has enough permission for the path.
+ * Allocate an IT context to 1394 OHCI controller. A local node of the node corresponding to the
+ * given path is used as the controller, thus any path is accepted as long as process has enough
+ * permission for the path.
  */
 void hinoko_fw_iso_tx_allocate(HinokoFwIsoTx *self, const char *path,
 			       HinokoFwScode scode, guint channel,
@@ -117,7 +113,7 @@ void hinoko_fw_iso_tx_allocate(HinokoFwIsoTx *self, const char *path,
 
 /**
  * hinoko_fw_iso_tx_release:
- * @self: A #HinokoFwIsoTx.
+ * @self: A [class@FwIsoTx].
  *
  * Release allocated IT context from 1394 OHCI controller.
  */
@@ -132,13 +128,12 @@ void hinoko_fw_iso_tx_release(HinokoFwIsoTx *self)
 
 /**
  * hinoko_fw_iso_tx_map_buffer:
- * @self: A #HinokoFwIsoTx.
+ * @self: A [class@FwIsoTx].
  * @maximum_bytes_per_payload: The number of bytes for payload of IT context.
  * @payloads_per_buffer: The number of payloads of IT context in buffer.
- * @error: A #GError.
+ * @error: A [struct@GLib.Error].
  *
- * Map intermediate buffer to share payload of IT context with 1394 OHCI
- * controller.
+ * Map intermediate buffer to share payload of IT context with 1394 OHCI controller.
  */
 void hinoko_fw_iso_tx_map_buffer(HinokoFwIsoTx *self,
 				 guint maximum_bytes_per_payload,
@@ -160,10 +155,9 @@ void hinoko_fw_iso_tx_map_buffer(HinokoFwIsoTx *self,
 
 /**
  * hinoko_fw_iso_tx_unmap_buffer:
- * @self: A #HinokoFwIsoTx.
+ * @self: A [class@FwIsoTx].
  *
- * Unmap intermediate buffer shard with 1394 OHCI controller for payload
- * of IT context.
+ * Unmap intermediate buffer shard with 1394 OHCI controller for payload of IT context.
  */
 void hinoko_fw_iso_tx_unmap_buffer(HinokoFwIsoTx *self)
 {
@@ -176,13 +170,12 @@ void hinoko_fw_iso_tx_unmap_buffer(HinokoFwIsoTx *self)
 
 /**
  * hinoko_fw_iso_tx_start:
- * @self: A #HinokoFwIsoTx.
- * @cycle_match: (array fixed-size=2) (element-type guint16) (in) (nullable):
- * 		 The isochronous cycle to start packet processing. The first
- * 		 element should be the second part of isochronous cycle, up to
- * 		 3. The second element should be the cycle part of isochronous
- * 		 cycle, up to 7999.
- * @error: A #GError.
+ * @self: A [class@FwIsoTx].
+ * @cycle_match: (array fixed-size=2) (element-type guint16) (in) (nullable): The isochronous cycle
+ *		 to start packet processing. The first element should be the second part of
+ *		 isochronous cycle, up to 3. The second element should be the cycle part of
+ *		 isochronous cycle, up to 7999.
+ * @error: A [struct@GLib.Error].
  *
  * Start IT context.
  *
@@ -199,7 +192,7 @@ void hinoko_fw_iso_tx_start(HinokoFwIsoTx *self, const guint16 *cycle_match, GEr
 
 /**
  * hinoko_fw_iso_tx_stop:
- * @self: A #HinokoFwIsoTx.
+ * @self: A [class@FwIsoTx].
  *
  * Stop IT context.
  */
@@ -217,21 +210,20 @@ void hinoko_fw_iso_tx_stop(HinokoFwIsoTx *self)
 
 /**
  * hinoko_fw_iso_tx_register_packet:
- * @self: A #HinokoFwIsoTx.
+ * @self: A [class@FwIsoTx].
  * @tags: The value of tag field for isochronous packet to register.
  * @sy: The value of sy field for isochronous packet to register.
- * @header: (array length=header_length)(nullable): The header of IT context
- * 	    for isochronous packet.
+ * @header: (array length=header_length)(nullable): The header of IT context for isochronous packet.
  * @header_length: The number of bytes for the @header.
- * @payload: (array length=payload_length)(nullable): The payload of IT context
- * 	     for isochronous packet.
+ * @payload: (array length=payload_length)(nullable): The payload of IT context for isochronous
+ *	     packet.
  * @payload_length: The number of bytes for the @payload.
  * @schedule_interrupt: Whether to schedule hardware interrupt at isochronous cycle for the packet.
- * @error: A #GError.
+ * @error: A [struct@GLib.Error].
  *
  * Register packet data with header and payload for IT context. The caller can schedule hardware
  * interrupt to generate interrupt event. In detail, please refer to documentation about
- * #HinokoFwIsoTx::interrupted.
+ * [signal@FwIsoTx::interrupted].
  *
  * Since: 0.6.
  */

--- a/src/fw_iso_tx.c
+++ b/src/fw_iso_tx.c
@@ -97,7 +97,7 @@ HinokoFwIsoTx *hinoko_fw_iso_tx_new(void)
  * @scode: A #HinokoFwScode to indicate speed of isochronous communication.
  * @channel: An isochronous channel to transfer.
  * @header_size: The number of bytes for header of IT context.
- * @exception: A #GError.
+ * @error: A #GError.
  *
  * Allocate an IT context to 1394 OHCI controller. A local node of the node
  * corresponding to the given path is used as the controller, thus any path is
@@ -105,14 +105,14 @@ HinokoFwIsoTx *hinoko_fw_iso_tx_new(void)
  */
 void hinoko_fw_iso_tx_allocate(HinokoFwIsoTx *self, const char *path,
 			       HinokoFwScode scode, guint channel,
-			       guint header_size, GError **exception)
+			       guint header_size, GError **error)
 {
 	g_return_if_fail(HINOKO_IS_FW_ISO_TX(self));
-	g_return_if_fail(exception != NULL && *exception == NULL);
+	g_return_if_fail(error != NULL && *error == NULL);
 
 	hinoko_fw_iso_ctx_allocate(HINOKO_FW_ISO_CTX(self), path,
 				   HINOKO_FW_ISO_CTX_MODE_TX, scode, channel,
-				   header_size, exception);
+				   header_size, error);
 }
 
 /**
@@ -135,7 +135,7 @@ void hinoko_fw_iso_tx_release(HinokoFwIsoTx *self)
  * @self: A #HinokoFwIsoTx.
  * @maximum_bytes_per_payload: The number of bytes for payload of IT context.
  * @payloads_per_buffer: The number of payloads of IT context in buffer.
- * @exception: A #GError.
+ * @error: A #GError.
  *
  * Map intermediate buffer to share payload of IT context with 1394 OHCI
  * controller.
@@ -143,17 +143,17 @@ void hinoko_fw_iso_tx_release(HinokoFwIsoTx *self)
 void hinoko_fw_iso_tx_map_buffer(HinokoFwIsoTx *self,
 				 guint maximum_bytes_per_payload,
 				 guint payloads_per_buffer,
-				 GError **exception)
+				 GError **error)
 {
 	HinokoFwIsoTxPrivate *priv;
 
 	g_return_if_fail(HINOKO_IS_FW_ISO_TX(self));
-	g_return_if_fail(exception != NULL && *exception == NULL);
+	g_return_if_fail(error != NULL && *error == NULL);
 	priv = hinoko_fw_iso_tx_get_instance_private(self);
 
 	hinoko_fw_iso_ctx_map_buffer(HINOKO_FW_ISO_CTX(self),
 				     maximum_bytes_per_payload,
-				     payloads_per_buffer, exception);
+				     payloads_per_buffer, error);
 
 	priv->offset = 0;
 }
@@ -182,18 +182,18 @@ void hinoko_fw_iso_tx_unmap_buffer(HinokoFwIsoTx *self)
  * 		 element should be the second part of isochronous cycle, up to
  * 		 3. The second element should be the cycle part of isochronous
  * 		 cycle, up to 7999.
- * @exception: A #GError.
+ * @error: A #GError.
  *
  * Start IT context.
  *
  * Since: 0.6.
  */
-void hinoko_fw_iso_tx_start(HinokoFwIsoTx *self, const guint16 *cycle_match, GError **exception)
+void hinoko_fw_iso_tx_start(HinokoFwIsoTx *self, const guint16 *cycle_match, GError **error)
 {
 	g_return_if_fail(HINOKO_IS_FW_ISO_TX(self));
-	g_return_if_fail(exception != NULL && *exception == NULL);
+	g_return_if_fail(error != NULL && *error == NULL);
 
-	hinoko_fw_iso_ctx_start(HINOKO_FW_ISO_CTX(self), cycle_match, 0, 0, exception);
+	hinoko_fw_iso_ctx_start(HINOKO_FW_ISO_CTX(self), cycle_match, 0, 0, error);
 
 }
 
@@ -227,7 +227,7 @@ void hinoko_fw_iso_tx_stop(HinokoFwIsoTx *self)
  * 	     for isochronous packet.
  * @payload_length: The number of bytes for the @payload.
  * @schedule_interrupt: Whether to schedule hardware interrupt at isochronous cycle for the packet.
- * @exception: A #GError.
+ * @error: A #GError.
  *
  * Register packet data with header and payload for IT context. The caller can schedule hardware
  * interrupt to generate interrupt event. In detail, please refer to documentation about
@@ -239,7 +239,7 @@ void hinoko_fw_iso_tx_register_packet(HinokoFwIsoTx *self,
 				HinokoFwIsoCtxMatchFlag tags, guint sy,
 				const guint8 *header, guint header_length,
 				const guint8 *payload, guint payload_length,
-				gboolean schedule_interrupt, GError **exception)
+				gboolean schedule_interrupt, GError **error)
 {
 	HinokoFwIsoTxPrivate *priv;
 	const guint8 *frames;
@@ -251,7 +251,7 @@ void hinoko_fw_iso_tx_register_packet(HinokoFwIsoTx *self,
 			 (header == NULL && header_length == 0));
 	g_return_if_fail((payload != NULL && payload_length > 0) ||
 			 (payload == NULL && payload_length == 0));
-	g_return_if_fail(exception != NULL && *exception == NULL);
+	g_return_if_fail(error != NULL && *error == NULL);
 
 	priv = hinoko_fw_iso_tx_get_instance_private(self);
 
@@ -261,8 +261,8 @@ void hinoko_fw_iso_tx_register_packet(HinokoFwIsoTx *self,
 
 	hinoko_fw_iso_ctx_register_chunk(HINOKO_FW_ISO_CTX(self), skip, tags, sy, header,
 					 header_length, payload_length, schedule_interrupt,
-					 exception);
-	if (*exception != NULL)
+					 error);
+	if (*error != NULL)
 		return;
 
 	hinoko_fw_iso_ctx_read_frames(HINOKO_FW_ISO_CTX(self), priv->offset,
@@ -284,7 +284,7 @@ void hinoko_fw_iso_tx_register_packet(HinokoFwIsoTx *self,
 
 void hinoko_fw_iso_tx_handle_event(HinokoFwIsoTx *self,
 				   struct fw_cdev_event_iso_interrupt *event,
-				   GError **exception)
+				   GError **error)
 {
 	guint sec = (event->cycle & 0x0000e000) >> 13;
 	guint cycle = event->cycle & 0x00001fff;

--- a/src/fw_iso_tx.h
+++ b/src/fw_iso_tx.h
@@ -15,15 +15,15 @@ struct _HinokoFwIsoTxClass {
 
 	/**
 	 * HinokoFwIsoTxClass::interrupted:
-	 * @self: A #HinokoFwIsoTx.
+	 * @self: A [class@FwIsoTx].
 	 * @sec: sec part of isochronous cycle when interrupt occurs.
 	 * @cycle: cycle part of of isochronous cycle when interrupt occurs.
-	 * @tstamp: (array length=tstamp_length) (element-type guint8): A series
-	 *	    of timestamps for packets already handled.
+	 * @tstamp: (array length=tstamp_length) (element-type guint8): A series of timestamps for
+	 *	    packets already handled.
 	 * @tstamp_length: the number of bytes for @tstamp.
 	 * @count: the number of handled packets.
 	 *
-	 * In detail, please refer to documentation about #HinokoFwIsoTx::interrupted.
+	 * Class closure for the [signal@FwIsoTx::interrupted] signal.
 	 */
 	void (*interrupted)(HinokoFwIsoTx *self, guint sec, guint cycle,
 			    const guint8 *tstamp, guint tstamp_length,

--- a/src/fw_iso_tx.h
+++ b/src/fw_iso_tx.h
@@ -34,23 +34,23 @@ HinokoFwIsoTx *hinoko_fw_iso_tx_new(void);
 
 void hinoko_fw_iso_tx_allocate(HinokoFwIsoTx *self, const char *path,
 			       HinokoFwScode scode, guint channel,
-			       guint header_size, GError **exception);
+			       guint header_size, GError **error);
 void hinoko_fw_iso_tx_release(HinokoFwIsoTx *self);
 
 void hinoko_fw_iso_tx_map_buffer(HinokoFwIsoTx *self,
 				 guint maximum_bytes_per_payload,
 				 guint payloads_per_buffer,
-				 GError **exception);
+				 GError **error);
 void hinoko_fw_iso_tx_unmap_buffer(HinokoFwIsoTx *self);
 
-void hinoko_fw_iso_tx_start(HinokoFwIsoTx *self, const guint16 *cycle_match, GError **exception);
+void hinoko_fw_iso_tx_start(HinokoFwIsoTx *self, const guint16 *cycle_match, GError **error);
 void hinoko_fw_iso_tx_stop(HinokoFwIsoTx *self);
 
 void hinoko_fw_iso_tx_register_packet(HinokoFwIsoTx *self,
 				HinokoFwIsoCtxMatchFlag tags, guint sy,
 				const guint8 *header, guint header_length,
 				const guint8 *payload, guint payload_length,
-				gboolean schedule_interrupt, GError **exception);
+				gboolean schedule_interrupt, GError **error);
 
 G_END_DECLS
 

--- a/src/hinoko_enum_types.h
+++ b/src/hinoko_enum_types.h
@@ -65,7 +65,7 @@ typedef enum /*< flags >*/
  * @HINOKO_FW_ISO_RESOURCE_ERROR_TIMEOUT:	No event to the request arrives within timeout.
  * @HINOKO_FW_ISO_RESOURCE_ERROR_EVENT:		Event for the request arrives but includes error code.
  *
- * A set of error code for GError with domain which equals to #hinoko_fw_iso_resource_error_quark();
+ * A set of error code for [class@FwIsoResource].
  */
 typedef enum {
 	HINOKO_FW_ISO_RESOURCE_ERROR_FAILED,
@@ -85,7 +85,7 @@ typedef enum {
  * @HINOKO_FW_ISO_RESOURCE_AUTO_ERROR_TIMEOUT:		No event to the request arrives within
  *							timeout.
  *
- * A set of error code for GError with domain which equals to #hinoko_fw_iso_resource_error_quark();
+ * A set of error code for [class@FwIsoResourceAuto].
  */
 typedef enum {
 	HINOKO_FW_ISO_RESOURCE_AUTO_ERROR_FAILED,
@@ -108,7 +108,7 @@ typedef enum {
  * @HINOKO_FW_ISO_CTX_ERROR_CHUNK_UNREGISTERED:	No chunk registered before starting.
  * @HINOKO_FW_ISO_CTX_ERROR_NO_ISOC_CHANNEL:	No isochronous channel is available.
  *
- * A set of error code for GError with domain which equals to #hinoko_fw_iso_ctx_error_quark();
+ * A set of error code for [class@FwIsoCtx].
  */
 typedef enum {
 	HINOKO_FW_ISO_CTX_ERROR_FAILED,

--- a/src/internal.h
+++ b/src/internal.h
@@ -33,7 +33,7 @@ void hinoko_fw_iso_rx_single_handle_event(HinokoFwIsoRxSingle *self,
 
 void hinoko_fw_iso_rx_multiple_handle_event(HinokoFwIsoRxMultiple *self,
 				struct fw_cdev_event_iso_interrupt_mc *event,
-				GError **exception);
+				GError **error);
 
 void hinoko_fw_iso_tx_handle_event(HinokoFwIsoTx *self,
 				   struct fw_cdev_event_iso_interrupt *event,

--- a/src/internal.h
+++ b/src/internal.h
@@ -41,7 +41,7 @@ void hinoko_fw_iso_tx_handle_event(HinokoFwIsoTx *self,
 
 void hinoko_fw_iso_resource_ioctl(HinokoFwIsoResource *self,
 				  unsigned long request, void *argp,
-				  GError **exception);
+				  GError **error);
 
 void hinoko_fw_iso_resource_auto_handle_event(HinokoFwIsoResourceAuto *self,
 					struct fw_cdev_event_iso_resource *ev);

--- a/src/internal.h
+++ b/src/internal.h
@@ -29,7 +29,7 @@ void hinoko_fw_iso_ctx_read_frames(HinokoFwIsoCtx *self, guint offset,
 
 void hinoko_fw_iso_rx_single_handle_event(HinokoFwIsoRxSingle *self,
 				struct fw_cdev_event_iso_interrupt *event,
-				GError **exception);
+				GError **error);
 
 void hinoko_fw_iso_rx_multiple_handle_event(HinokoFwIsoRxMultiple *self,
 				struct fw_cdev_event_iso_interrupt_mc *event,

--- a/src/internal.h
+++ b/src/internal.h
@@ -37,7 +37,7 @@ void hinoko_fw_iso_rx_multiple_handle_event(HinokoFwIsoRxMultiple *self,
 
 void hinoko_fw_iso_tx_handle_event(HinokoFwIsoTx *self,
 				   struct fw_cdev_event_iso_interrupt *event,
-				   GError **exception);
+				   GError **error);
 
 void hinoko_fw_iso_resource_ioctl(HinokoFwIsoResource *self,
 				  unsigned long request, void *argp,

--- a/src/internal.h
+++ b/src/internal.h
@@ -7,21 +7,21 @@
 void hinoko_fw_iso_ctx_allocate(HinokoFwIsoCtx *self, const char *path,
 				HinokoFwIsoCtxMode mode, HinokoFwScode scode,
 				guint channel, guint header_size,
-				GError **exception);
+				GError **error);
 void hinoko_fw_iso_ctx_release(HinokoFwIsoCtx *self);
 void hinoko_fw_iso_ctx_map_buffer(HinokoFwIsoCtx *self, guint bytes_per_chunk,
-				  guint chunks_per_buffer, GError **exception);
+				  guint chunks_per_buffer, GError **error);
 void hinoko_fw_iso_ctx_unmap_buffer(HinokoFwIsoCtx *self);
 void hinoko_fw_iso_ctx_register_chunk(HinokoFwIsoCtx *self, gboolean skip,
 				      HinokoFwIsoCtxMatchFlag tags, guint sy,
 				      const guint8 *header, guint header_length,
 				      guint payload_length, gboolean schedule_interrupt,
-				      GError **exception);
+				      GError **error);
 void hinoko_fw_iso_ctx_set_rx_channels(HinokoFwIsoCtx *self,
 				       guint64 *channel_flags,
-				       GError **exception);
+				       GError **error);
 void hinoko_fw_iso_ctx_start(HinokoFwIsoCtx *self, const guint16 *cycle_match, guint32 sync,
-			     HinokoFwIsoCtxMatchFlag tags, GError **exception);
+			     HinokoFwIsoCtxMatchFlag tags, GError **error);
 void hinoko_fw_iso_ctx_stop(HinokoFwIsoCtx *self);
 void hinoko_fw_iso_ctx_read_frames(HinokoFwIsoCtx *self, guint offset,
 				   guint length, const guint8 **frames,


### PR DESCRIPTION
The gi-docgen supports enhancement of inter-document link:

 * https://gnome.pages.gitlab.gnome.org/gi-docgen/linking.html

This patchset is optimization to it. ~~Unfortunately, released version of gi-docgen
has [a bug to generate link for error domain](https://gitlab.gnome.org/GNOME/gi-docgen/-/merge_requests/151), thus local CI fails as expected.~~

```
Takashi Sakamoto (15):
  enums: link optimization to gi-docgen
  cycle_timer: link optimization to gi-docgen
  fw_iso_ctx: rename exception with error
  fw_iso_ctx: link optimization to gi-docgen
  fw_iso_rx_single: rename exception with error
  fw_iso_rx_single: link optimization to gi-docgen
  fw_iso_rx_multiple: replace exception with error
  fw_iso_rx_multiple: link optimization to gi-docgen
  fw_iso_tx: rename exception with error
  fw_iso_tx: link optimization to gi-docgen
  fw_iso_resource: replace exception with error
  fw_iso_resource: link optimization to gi-docgen
  fw_iso_resource_auto: rename exception with error
  fw_iso_resource_auto: link optimization to gi-docgen
  update README

 README.rst                 |  20 ++--
 src/cycle_timer.c          |  35 +++---
 src/fw_iso_ctx.c           | 239 ++++++++++++++++++-------------------
 src/fw_iso_ctx.h           |  13 +-
 src/fw_iso_resource.c      | 164 ++++++++++++-------------
 src/fw_iso_resource.h      |  32 +++--
 src/fw_iso_resource_auto.c | 109 ++++++++---------
 src/fw_iso_resource_auto.h |   8 +-
 src/fw_iso_rx_multiple.c   | 134 ++++++++++-----------
 src/fw_iso_rx_multiple.h   |  12 +-
 src/fw_iso_rx_single.c     | 120 +++++++++----------
 src/fw_iso_rx_single.h     |  20 ++--
 src/fw_iso_tx.c            | 112 ++++++++---------
 src/fw_iso_tx.h            |  16 +--
 src/hinoko_enum_types.h    |   6 +-
 src/internal.h             |  18 +--
 16 files changed, 503 insertions(+), 555 deletions(-)
```