### PR TITLE
[PATCH 0/9] add Hinoko.FwIsoResourceOnce to make Hinoko.FwIsoResource as abstract object

### DIFF
--- a/samples/iso-resource
+++ b/samples/iso-resource
@@ -27,7 +27,7 @@ def handle_event(res, channel, bandwidth, exception, ev_name):
 
 # For Once mode. The allocation is bound to current generation of the bus and
 # lost automatically by bus reset without notification.
-res = Hinoko.FwIsoResource.new()
+res = Hinoko.FwIsoResourceOnce.new()
 res.open('/dev/fw0', 0)
 res.connect('allocated', handle_event, 'allocated')
 res.connect('deallocated', handle_event, 'deallocated')
@@ -37,7 +37,7 @@ src.attach(ctx)
 
 for i in range(2):
     try:
-        res.allocate_once_sync((use_channel, ), use_bandwidth)
+        res.allocate_sync((use_channel, ), use_bandwidth, 100)
     except GLib.Error as e:
         if e.matches(Hinoko.fw_iso_resource_error_quark(), Hinoko.FwIsoResourceError.EVENT):
             print(e)
@@ -48,7 +48,7 @@ for i in range(2):
     sleep(2)
 
     try:
-        res.deallocate_once_sync(use_channel, use_bandwidth)
+        res.deallocate_sync(use_channel, use_bandwidth, 100)
     except GLib.Error as e:
         if e.matches(Hinoko.fw_iso_resource_error_quark(), Hinoko.FwIsoResourceError.EVENT):
             print(e)

--- a/samples/iso-resource
+++ b/samples/iso-resource
@@ -80,7 +80,7 @@ for i in range(2):
     print_props(res)
 
     try:
-        res.allocate_sync([use_channel], use_bandwidth)
+        res.allocate_sync([use_channel], use_bandwidth, 100)
     except GLib.Error as e:
         if e.matches(Hinoko.fw_iso_resource_error_quark(), Hinoko.FwIsoResourceError.EVENT):
             print(e)
@@ -91,7 +91,7 @@ for i in range(2):
     sleep(1)
 
     try:
-        res.deallocate_sync()
+        res.deallocate_sync(100)
     except GLib.Error as e:
         if e.matches(Hinoko.fw_iso_resource_error_quark(), Hinoko.FwIsoResourceError.EVENT):
             print(e)

--- a/src/fw_iso_ctx.c
+++ b/src/fw_iso_ctx.c
@@ -164,7 +164,7 @@ static void hinoko_fw_iso_ctx_class_init(HinokoFwIsoCtxClass *klass)
 	/**
 	 * HinokoFwIsoCtx::stopped:
 	 * @self: A [class@FwIsoCtx].
-	 * @error: (nullable): A [struct@GLib.Error].
+	 * @error: (transfer none) (nullable): A [struct@GLib.Error].
 	 *
 	 * Emitted when isochronous context is stopped.
 	 */

--- a/src/fw_iso_ctx.h
+++ b/src/fw_iso_ctx.h
@@ -20,7 +20,7 @@ struct _HinokoFwIsoCtxClass {
 	/**
 	 * HinokoFwIsoCtxClass::stopped:
 	 * @self: A [class@FwIsoCtx].
-	 * @error: (nullable): A [struct@GLib.Error].
+	 * @error: (transfer none) (nullable): A [struct@GLib.Error].
 	 *
 	 * Class closure for the [signal@FwIsoCtx::stopped] signal.
 	 */

--- a/src/fw_iso_resource.c
+++ b/src/fw_iso_resource.c
@@ -10,16 +10,16 @@
 
 /**
  * HinokoFwIsoResource:
- * An object to initiate requests and listen events of isochronous resource allocation/deallocation.
+ * An abstract object to listen events of isochronous resource allocation/deallocation.
  *
- * A [class@FwIsoResource] is an object to initiate requests and listen events of isochronous
- * resource allocation/deallocation by file descriptor owned internally. This object is designed to
- * be used for any derived object.
+ * The [class@FwIsoResource] is an abstract object to listen events of isochronous resource
+ * allocation/deallocation by file descriptor owned internally. This object is designed to be used
+ * for any derived object.
  */
 typedef struct {
 	int fd;
 } HinokoFwIsoResourcePrivate;
-G_DEFINE_TYPE_WITH_PRIVATE(HinokoFwIsoResource, hinoko_fw_iso_resource, G_TYPE_OBJECT)
+G_DEFINE_ABSTRACT_TYPE_WITH_PRIVATE(HinokoFwIsoResource, hinoko_fw_iso_resource, G_TYPE_OBJECT)
 
 /**
  * hinoko_fw_iso_resource_error_quark:
@@ -135,18 +135,6 @@ static void hinoko_fw_iso_resource_init(HinokoFwIsoResource *self)
 	HinokoFwIsoResourcePrivate *priv =
 			hinoko_fw_iso_resource_get_instance_private(self);
 	priv->fd = -1;
-}
-
-/**
- * hinoko_fw_iso_resource_new:
- *
- * Allocate and return an instance of [class@FwIsoResource].
- *
- * Returns: A [class@FwIsoResource].
- */
-HinokoFwIsoResource *hinoko_fw_iso_resource_new()
-{
-	return g_object_new(HINOKO_TYPE_FW_ISO_RESOURCE, NULL);
 }
 
 /**

--- a/src/fw_iso_resource.c
+++ b/src/fw_iso_resource.c
@@ -94,8 +94,8 @@ static void hinoko_fw_iso_resource_class_init(HinokoFwIsoResourceClass *klass)
 	 * @self: A [class@FwIsoResource].
 	 * @channel: The deallocated channel number.
 	 * @bandwidth: The deallocated amount of bandwidth.
-	 * @error: A [struct@GLib.Error]. Error can be generated with domain of
-	 *	   Hinoko.FwIsoResourceError and its EVENT code.
+	 * @error: (transfer none) (nullable): A [struct@GLib.Error]. Error can be generated with
+	 *	   domain of Hinoko.FwIsoResourceError and its EVENT code.
 	 *
 	 * Emitted when allocation of isochronous resource finishes.
 	 */
@@ -114,8 +114,8 @@ static void hinoko_fw_iso_resource_class_init(HinokoFwIsoResourceClass *klass)
 	 * @self: A [class@FwIsoResource].
 	 * @channel: The deallocated channel number.
 	 * @bandwidth: The deallocated amount of bandwidth.
-	 * @error: A [struct@GLib.Error]. Error can be generated with domain of
-	 *	   Hinoko.FwIsoResourceError and its EVENT code.
+	 * @error: (transfer none) (nullable): A [struct@GLib.Error]. Error can be generated with
+	 *	   domain of Hinoko.FwIsoResourceError and its EVENT code.
 	 *
 	 * Emitted when deallocation of isochronous resource finishes.
 	 */
@@ -447,7 +447,7 @@ static void handle_iso_resource_event(HinokoFwIsoResource *self,
 	guint channel;
 	guint bandwidth;
 	int sig_type;
-	GError *error;
+	GError *error = NULL;
 
 	// To change state machine for auto mode.
 	if (HINOKO_IS_FW_ISO_RESOURCE_AUTO(self)) {
@@ -458,7 +458,6 @@ static void handle_iso_resource_event(HinokoFwIsoResource *self,
 	if (ev->channel >= 0) {
 		channel = ev->channel;
 		bandwidth = ev->bandwidth;
-		error = NULL;
 	} else {
 		channel = 0;
 		bandwidth = 0;

--- a/src/fw_iso_resource.h
+++ b/src/fw_iso_resource.h
@@ -45,8 +45,6 @@ struct _HinokoFwIsoResourceClass {
 			    guint bandwidth, const GError *error);
 };
 
-HinokoFwIsoResource *hinoko_fw_iso_resource_new();
-
 void hinoko_fw_iso_resource_open(HinokoFwIsoResource *self, const gchar *path,
 				 gint open_flag, GError **error);
 

--- a/src/fw_iso_resource.h
+++ b/src/fw_iso_resource.h
@@ -56,28 +56,6 @@ void hinoko_fw_iso_resource_create_source(HinokoFwIsoResource *self,
 guint hinoko_fw_iso_resource_calculate_bandwidth(guint bytes_per_payload,
 						 HinokoFwScode scode);
 
-void hinoko_fw_iso_resource_allocate_once_async(HinokoFwIsoResource *self,
-						guint8 *channel_candidates,
-						gsize channel_candidates_count,
-						guint bandwidth,
-						GError **error);
-
-void hinoko_fw_iso_resource_deallocate_once_async(HinokoFwIsoResource *self,
-						  guint channel,
-						  guint bandwidth,
-						  GError **error);
-
-void hinoko_fw_iso_resource_allocate_once_sync(HinokoFwIsoResource *self,
-					       guint8 *channel_candidates,
-					       gsize channel_candidates_count,
-					       guint bandwidth,
-					       GError **error);
-
-void hinoko_fw_iso_resource_deallocate_once_sync(HinokoFwIsoResource *self,
-						 guint channel,
-						 guint bandwidth,
-						 GError **error);
-
 G_END_DECLS
 
 #endif

--- a/src/fw_iso_resource.h
+++ b/src/fw_iso_resource.h
@@ -23,8 +23,8 @@ struct _HinokoFwIsoResourceClass {
 	 * @self: A [class@FwIsoResource].
 	 * @channel: The deallocated channel number.
 	 * @bandwidth: The deallocated amount of bandwidth.
-	 * @error: A [struct@GLib.Error]. Error can be generated with domain of
-	 *	   Hinoko.FwIsoResourceError and its EVENT code.
+	 * @error: (transfer none) (nullable): A [struct@GLib.Error]. Error can be generated with
+	 *	   domain of Hinoko.FwIsoResourceError and its EVENT code.
 	 *
 	 * Class closure for the [signal@FwIsoResource::allocated] signal.
 	 */
@@ -36,8 +36,8 @@ struct _HinokoFwIsoResourceClass {
 	 * @self: A [class@FwIsoResource].
 	 * @channel: The deallocated channel number.
 	 * @bandwidth: The deallocated amount of bandwidth.
-	 * @error: A [struct@GLib.Error]. Error can be generated with domain of
-	 *	   Hinoko.FwIsoResourceError and its EVENT code.
+	 * @error: (transfer none) (nullable): A [struct@GLib.Error]. Error can be generated with
+	 *	   domain of Hinoko.FwIsoResourceError and its EVENT code.
 	 *
 	 * Class closure for the [signal@FwIsoResource::deallocated] signal.
 	 */

--- a/src/fw_iso_resource_auto.c
+++ b/src/fw_iso_resource_auto.c
@@ -223,17 +223,20 @@ end:
  *			numerical number for isochronous channel to be allocated.
  * @channel_candidates_count: The number of channel candidates.
  * @bandwidth: The amount of bandwidth to be allocated.
+ * @timeout_ms: The timeout to wait for allocated event.
  * @error: A [struct@GLib.Error]. Error can be generated with domain of
  *	   Hinoko.FwIsoResourceError, and Hinoko.FwIsoResourceAutoError.
  *
  * Initiate allocation of isochronous resource and wait for [signal@FwIsoResource::allocated]
  * signal. When the call is successful, [property@FwIsoResourceAuto:channel] and
  * [property@FwIsoResourceAuto:bandwidth] properties are available.
+ *
+ * Since: 0.7.
  */
 void hinoko_fw_iso_resource_auto_allocate_sync(HinokoFwIsoResourceAuto *self,
 					       guint8 *channel_candidates,
 					       gsize channel_candidates_count,
-					       guint bandwidth,
+					       guint bandwidth, guint timeout_ms,
 					       GError **error)
 {
 	struct fw_iso_resource_waiter w;
@@ -241,7 +244,7 @@ void hinoko_fw_iso_resource_auto_allocate_sync(HinokoFwIsoResourceAuto *self,
 	g_return_if_fail(HINOKO_IS_FW_ISO_RESOURCE_AUTO(self));
 	g_return_if_fail(error != NULL && *error == NULL);
 
-	fw_iso_resource_waiter_init(HINOKO_FW_ISO_RESOURCE(self), &w, "allocated", 100);
+	fw_iso_resource_waiter_init(HINOKO_FW_ISO_RESOURCE(self), &w, "allocated", timeout_ms);
 
 	hinoko_fw_iso_resource_auto_allocate_async(self, channel_candidates,
 						   channel_candidates_count,
@@ -253,13 +256,16 @@ void hinoko_fw_iso_resource_auto_allocate_sync(HinokoFwIsoResourceAuto *self,
 /**
  * hinoko_fw_iso_resource_auto_deallocate_sync:
  * @self: A [class@FwIsoResourceAuto]
+ * @timeout_ms: The timeout to wait for allocated event by milli second unit.
  * @error: A [struct@GLib.Error]. Error can be generated with domain of
  *	   Hinoko.FwIsoResourceError, and Hinoko.FwIsoResourceAutoError.
  *
  * Initiate deallocation of isochronous resource. When the deallocation is done,
  * [signal@FwIsoResource::deallocated] signal is emit to notify the result, channel, and bandwidth.
+ *
+ * Since: 0.7.
  */
-void hinoko_fw_iso_resource_auto_deallocate_sync(HinokoFwIsoResourceAuto *self,
+void hinoko_fw_iso_resource_auto_deallocate_sync(HinokoFwIsoResourceAuto *self, guint timeout_ms,
 						 GError **error)
 {
 	struct fw_iso_resource_waiter w;
@@ -267,7 +273,7 @@ void hinoko_fw_iso_resource_auto_deallocate_sync(HinokoFwIsoResourceAuto *self,
 	g_return_if_fail(HINOKO_IS_FW_ISO_RESOURCE_AUTO(self));
 	g_return_if_fail(error != NULL && *error == NULL);
 
-	fw_iso_resource_waiter_init(HINOKO_FW_ISO_RESOURCE(self), &w, "deallocated", 100);
+	fw_iso_resource_waiter_init(HINOKO_FW_ISO_RESOURCE(self), &w, "deallocated", timeout_ms);
 
 	hinoko_fw_iso_resource_auto_deallocate_async(self, error);
 

--- a/src/fw_iso_resource_auto.c
+++ b/src/fw_iso_resource_auto.c
@@ -349,25 +349,26 @@ void hinoko_fw_iso_resource_auto_deallocate_sync(HinokoFwIsoResourceAuto *self,
 		*error = w.error;	// Delegate ownership.
 }
 
-void hinoko_fw_iso_resource_auto_handle_event(HinokoFwIsoResourceAuto *self,
-					struct fw_cdev_event_iso_resource *ev)
+void hinoko_fw_iso_resource_auto_handle_event(HinokoFwIsoResourceAuto *self, guint channel,
+					      guint bandwidth, const char *signal_name,
+					      const GError *error)
 {
 	HinokoFwIsoResourceAutoPrivate *priv =
 			hinoko_fw_iso_resource_auto_get_instance_private(self);
 
-	if (ev->type == FW_CDEV_EVENT_ISO_RESOURCE_ALLOCATED) {
-		if (ev->channel >= 0) {
+	if (!strcmp(signal_name, "allocated")) {
+		if (error == NULL) {
 			g_mutex_lock(&priv->mutex);
-			priv->channel = ev->channel;
-			priv->bandwidth = ev->bandwidth;
+			priv->channel = channel;
+			priv->bandwidth = bandwidth;
 			priv->allocated = TRUE;
 			g_mutex_unlock(&priv->mutex);
 		}
-	} else {
-		if (ev->channel >= 0) {
+	} else if (!strcmp(signal_name, "deallocated")) {
+		if (error == NULL) {
 			g_mutex_lock(&priv->mutex);
 			priv->channel = 0;
-			priv->bandwidth -= ev->bandwidth;
+			priv->bandwidth -= bandwidth;
 			priv->allocated = FALSE;
 			g_mutex_unlock(&priv->mutex);
 		}

--- a/src/fw_iso_resource_auto.h
+++ b/src/fw_iso_resource_auto.h
@@ -29,12 +29,12 @@ void hinoko_fw_iso_resource_auto_allocate_async(HinokoFwIsoResourceAuto *self,
 void hinoko_fw_iso_resource_auto_allocate_sync(HinokoFwIsoResourceAuto *self,
 					       guint8 *channel_candidates,
 					       gsize channel_candidates_count,
-					       guint bandwidth,
+					       guint bandwidth, guint timeout_ms,
 					       GError **error);
 
 void hinoko_fw_iso_resource_auto_deallocate_async(HinokoFwIsoResourceAuto *self,
 						  GError **error);
-void hinoko_fw_iso_resource_auto_deallocate_sync(HinokoFwIsoResourceAuto *self,
+void hinoko_fw_iso_resource_auto_deallocate_sync(HinokoFwIsoResourceAuto *self, guint timeout_ms,
 						 GError **error);
 
 G_END_DECLS

--- a/src/fw_iso_resource_auto.h
+++ b/src/fw_iso_resource_auto.h
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
-#ifndef __HINOKO_FW_ISO_RESOURCE_AUTO_AUTO_H__
-#define __HINOKO_FW_ISO_RESOURCE_AUTO_AUTO_H__
+#ifndef __HINOKO_FW_ISO_RESOURCE_AUTO_H__
+#define __HINOKO_FW_ISO_RESOURCE_AUTO_H__
 
 #include <hinoko.h>
 

--- a/src/fw_iso_resource_once.c
+++ b/src/fw_iso_resource_once.c
@@ -35,3 +35,136 @@ HinokoFwIsoResourceOnce *hinoko_fw_iso_resource_once_new()
 {
 	return g_object_new(HINOKO_TYPE_FW_ISO_RESOURCE_ONCE, NULL);
 }
+
+/**
+ * hinoko_fw_iso_resource_once_allocate_async:
+ * @self: A [class@FwIsoResourceOnce].
+ * @channel_candidates: (array length=channel_candidates_count): The array with elements for
+ *			numeric number for isochronous channel to be allocated.
+ * @channel_candidates_count: The number of channel candidates.
+ * @bandwidth: The amount of bandwidth to be allocated.
+ * @error: A [struct@GLib.Error]. Error can be generated with domain of Hinoko.FwIsoResourceError.
+ *
+ * Initiate allocation of isochronous resource without any wait. When the allocation finishes,
+ * [signal@FwIsoResource::allocated] signal is emit to notify the result, channel, and bandwidth.
+ *
+ * Since: 0.7.
+ */
+void hinoko_fw_iso_resource_once_allocate_async(HinokoFwIsoResourceOnce *self,
+						guint8 *channel_candidates,
+						gsize channel_candidates_count,
+						guint bandwidth, GError **error)
+{
+	struct fw_cdev_allocate_iso_resource res = {0};
+	int i;
+
+	g_return_if_fail(HINOKO_IS_FW_ISO_RESOURCE_ONCE(self));
+	g_return_if_fail(error != NULL && *error == NULL);
+
+	g_return_if_fail(channel_candidates != NULL);
+	g_return_if_fail(channel_candidates_count > 0);
+	g_return_if_fail(bandwidth > 0);
+
+	for (i = 0; i < channel_candidates_count; ++i) {
+		if (channel_candidates[i] < 64)
+			res.channels |= 1ull << channel_candidates[i];
+	}
+	res.bandwidth = bandwidth;
+
+	hinoko_fw_iso_resource_ioctl(HINOKO_FW_ISO_RESOURCE(self),
+				     FW_CDEV_IOC_ALLOCATE_ISO_RESOURCE_ONCE, &res, error);
+}
+
+/**
+ * hinoko_fw_iso_resource_once_deallocate_async:
+ * @self: A [class@FwIsoResourceOnce].
+ * @channel: The channel number to be deallocated.
+ * @bandwidth: The amount of bandwidth to be deallocated.
+ * @error: A [struct@GLib.Error]. Error can be generated with domain of Hinoko.FwIsoResourceError.
+ *
+ * Initiate deallocation of isochronous resource without any wait. When the
+ * deallocation finishes, [signal@FwIsoResource::deallocated] signal is emit to notify the result,
+ * channel, and bandwidth.
+ *
+ * Since: 0.7.
+ */
+void hinoko_fw_iso_resource_once_deallocate_async(HinokoFwIsoResourceOnce *self, guint channel,
+						  guint bandwidth, GError **error)
+{
+	struct fw_cdev_allocate_iso_resource res = {0};
+
+	g_return_if_fail(HINOKO_IS_FW_ISO_RESOURCE_ONCE(self));
+	g_return_if_fail(error != NULL && *error == NULL);
+
+	g_return_if_fail(channel < 64);
+	g_return_if_fail(bandwidth > 0);
+
+	res.channels = 1ull << channel;
+	res.bandwidth = bandwidth;
+
+	hinoko_fw_iso_resource_ioctl(HINOKO_FW_ISO_RESOURCE(self),
+				     FW_CDEV_IOC_DEALLOCATE_ISO_RESOURCE_ONCE, &res, error);
+}
+
+/**
+ * hinoko_fw_iso_resource_once_allocate_sync:
+ * @self: A [class@FwIsoResourceOnce].
+ * @channel_candidates: (array length=channel_candidates_count): The array with elements for
+ *			numeric number for isochronous channel to be allocated.
+ * @channel_candidates_count: The number of channel candidates.
+ * @bandwidth: The amount of bandwidth to be allocated.
+ * @timeout_ms: The timeout to wait for allocated event.
+ * @error: A [struct@GLib.Error]. Error can be generated with domain of Hinoko.FwIsoResourceError.
+ *
+ * Initiate allocation of isochronous resource and wait for [signal@FwIsoResource::allocated]
+ * signal.
+ *
+ * Since: 0.7.
+ */
+void hinoko_fw_iso_resource_once_allocate_sync(HinokoFwIsoResourceOnce *self,
+					       guint8 *channel_candidates,
+					       gsize channel_candidates_count,
+					       guint bandwidth, guint timeout_ms,
+					       GError **error)
+{
+	struct fw_iso_resource_waiter w;
+
+	g_return_if_fail(HINOKO_IS_FW_ISO_RESOURCE_ONCE(self));
+	g_return_if_fail(error != NULL && *error == NULL);
+
+	fw_iso_resource_waiter_init(HINOKO_FW_ISO_RESOURCE(self), &w, "allocated", timeout_ms);
+
+	hinoko_fw_iso_resource_once_allocate_async(self, channel_candidates,
+						   channel_candidates_count, bandwidth, error);
+
+	fw_iso_resource_waiter_wait(HINOKO_FW_ISO_RESOURCE(self), &w, error);
+}
+
+/**
+ * hinoko_fw_iso_resource_once_deallocate_sync:
+ * @self: A [class@FwIsoResourceOnce].
+ * @channel: The channel number to be deallocated.
+ * @bandwidth: The amount of bandwidth to be deallocated.
+ * @timeout_ms: The timeout to wait for deallocated event.
+ * @error: A [struct@GLib.Error]. Error can be generated with domain of Hinoko.FwIsoResourceError.
+ *
+ * Initiate deallocation of isochronous resource and wait for [signal@FwIsoResource::deallocated]
+ * signal.
+ *
+ * Since: 0.7.
+ */
+void hinoko_fw_iso_resource_once_deallocate_sync(HinokoFwIsoResourceOnce *self, guint channel,
+						 guint bandwidth, guint timeout_ms,
+						 GError **error)
+{
+	struct fw_iso_resource_waiter w;
+
+	g_return_if_fail(HINOKO_IS_FW_ISO_RESOURCE_ONCE(self));
+	g_return_if_fail(error != NULL && *error == NULL);
+
+	fw_iso_resource_waiter_init(HINOKO_FW_ISO_RESOURCE(self), &w, "deallocated", timeout_ms);
+
+	hinoko_fw_iso_resource_once_deallocate_async(self, channel, bandwidth, error);
+
+	fw_iso_resource_waiter_wait(HINOKO_FW_ISO_RESOURCE(self), &w, error);
+}

--- a/src/fw_iso_resource_once.c
+++ b/src/fw_iso_resource_once.c
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+#include "internal.h"
+
+/**
+ * HinokoFwIsoResourceOnce:
+ * An object to initiate requests and listen events of isochronous resource allocation/deallocation
+ * by one shot.
+ *
+ * The [class@FwIsoResourceOnce] is an object to initiate requests and listen events of isochronous
+ * resource allocation/deallocation by file descriptor owned internally. The allocated resource
+ * is left even if this object is destroyed, thus application is responsible for deallocation.
+ */
+G_DEFINE_TYPE(HinokoFwIsoResourceOnce, hinoko_fw_iso_resource_once, HINOKO_TYPE_FW_ISO_RESOURCE)
+
+static void hinoko_fw_iso_resource_once_class_init(HinokoFwIsoResourceOnceClass *klass)
+{
+	return;
+}
+
+static void hinoko_fw_iso_resource_once_init(HinokoFwIsoResourceOnce *self)
+{
+	return;
+}
+
+/**
+ * hinoko_fw_iso_resource_once_new:
+ *
+ * Allocate and return an instance of [class@FwIsoResourceOnce].
+ *
+ * Returns: A [class@FwIsoResourceOnce].
+ *
+ * Sine: 0.7.
+ */
+HinokoFwIsoResourceOnce *hinoko_fw_iso_resource_once_new()
+{
+	return g_object_new(HINOKO_TYPE_FW_ISO_RESOURCE_ONCE, NULL);
+}

--- a/src/fw_iso_resource_once.h
+++ b/src/fw_iso_resource_once.h
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+#ifndef __HINOKO_FW_ISO_RESOURCE_ONCE_H__
+#define __HINOKO_FW_ISO_RESOURCE_ONCE_H__
+
+#include <hinoko.h>
+
+G_BEGIN_DECLS
+
+#define HINOKO_TYPE_FW_ISO_RESOURCE_ONCE	(hinoko_fw_iso_resource_once_get_type())
+
+G_DECLARE_DERIVABLE_TYPE(HinokoFwIsoResourceOnce, hinoko_fw_iso_resource_once, HINOKO,
+			 FW_ISO_RESOURCE_ONCE, HinokoFwIsoResource);
+
+struct _HinokoFwIsoResourceOnceClass {
+	HinokoFwIsoResourceClass parent_class;
+};
+
+HinokoFwIsoResourceOnce *hinoko_fw_iso_resource_once_new();
+
+G_END_DECLS
+
+#endif

--- a/src/fw_iso_resource_once.h
+++ b/src/fw_iso_resource_once.h
@@ -17,6 +17,24 @@ struct _HinokoFwIsoResourceOnceClass {
 
 HinokoFwIsoResourceOnce *hinoko_fw_iso_resource_once_new();
 
+void hinoko_fw_iso_resource_once_allocate_async(HinokoFwIsoResourceOnce *self,
+						guint8 *channel_candidates,
+						gsize channel_candidates_count,
+						guint bandwidth, GError **error);
+
+void hinoko_fw_iso_resource_once_deallocate_async(HinokoFwIsoResourceOnce *self, guint channel,
+						  guint bandwidth, GError **error);
+
+void hinoko_fw_iso_resource_once_allocate_sync(HinokoFwIsoResourceOnce *self,
+					       guint8 *channel_candidates,
+					       gsize channel_candidates_count,
+					       guint bandwidth, guint timeout_ms,
+					       GError **error);
+
+void hinoko_fw_iso_resource_once_deallocate_sync(HinokoFwIsoResourceOnce *self, guint channel,
+						 guint bandwidth, guint timeout_ms,
+						 GError **error);
+
 G_END_DECLS
 
 #endif

--- a/src/hinoko.h
+++ b/src/hinoko.h
@@ -22,5 +22,6 @@
 
 #include <fw_iso_resource.h>
 #include <fw_iso_resource_auto.h>
+#include <fw_iso_resource_once.h>
 
 #endif

--- a/src/hinoko.map
+++ b/src/hinoko.map
@@ -51,7 +51,6 @@ HINOKO_0_3_0 {
 HINOKO_0_4_0 {
   global:
     "hinoko_fw_iso_resource_get_type";
-    "hinoko_fw_iso_resource_new";
     "hinoko_fw_iso_resource_open";
     "hinoko_fw_iso_resource_create_source";
     "hinoko_fw_iso_resource_calculate_bandwidth";

--- a/src/hinoko.map
+++ b/src/hinoko.map
@@ -93,4 +93,7 @@ HINOKO_0_7_0 {
   global:
     "hinoko_fw_iso_resource_auto_allocate_sync";
     "hinoko_fw_iso_resource_auto_deallocate_sync";
+
+    "hinoko_fw_iso_resource_once_get_type";
+    "hinoko_fw_iso_resource_once_new";
 } HINOKO_0_5_0;

--- a/src/hinoko.map
+++ b/src/hinoko.map
@@ -64,8 +64,6 @@ HINOKO_0_4_0 {
     "hinoko_fw_iso_resource_auto_new";
     "hinoko_fw_iso_resource_auto_allocate_async";
     "hinoko_fw_iso_resource_auto_deallocate_async";
-    "hinoko_fw_iso_resource_auto_allocate_sync";
-    "hinoko_fw_iso_resource_auto_deallocate_sync";
 } HINOKO_0_3_0;
 
 HINOKO_0_5_0 {
@@ -89,4 +87,10 @@ HINOKO_0_6_0 {
 
     "hinoko_fw_iso_rx_single_register_packet";
     "hinoko_fw_iso_rx_single_start";
+} HINOKO_0_5_0;
+
+HINOKO_0_7_0 {
+  global:
+    "hinoko_fw_iso_resource_auto_allocate_sync";
+    "hinoko_fw_iso_resource_auto_deallocate_sync";
 } HINOKO_0_5_0;

--- a/src/hinoko.map
+++ b/src/hinoko.map
@@ -55,10 +55,6 @@ HINOKO_0_4_0 {
     "hinoko_fw_iso_resource_open";
     "hinoko_fw_iso_resource_create_source";
     "hinoko_fw_iso_resource_calculate_bandwidth";
-    "hinoko_fw_iso_resource_allocate_once_async";
-    "hinoko_fw_iso_resource_deallocate_once_async";
-    "hinoko_fw_iso_resource_allocate_once_sync";
-    "hinoko_fw_iso_resource_deallocate_once_sync";
 
     "hinoko_fw_iso_resource_auto_get_type";
     "hinoko_fw_iso_resource_auto_new";
@@ -96,4 +92,8 @@ HINOKO_0_7_0 {
 
     "hinoko_fw_iso_resource_once_get_type";
     "hinoko_fw_iso_resource_once_new";
+    "hinoko_fw_iso_resource_once_allocate_async";
+    "hinoko_fw_iso_resource_once_deallocate_async";
+    "hinoko_fw_iso_resource_once_allocate_sync";
+    "hinoko_fw_iso_resource_once_deallocate_sync";
 } HINOKO_0_5_0;

--- a/src/hinoko_enum_types.h
+++ b/src/hinoko_enum_types.h
@@ -82,8 +82,6 @@ typedef enum {
  *							allocated isochronous resources.
  * @HINOKO_FW_ISO_RESOURCE_AUTO_ERROR_NOT_ALLOCATED:	The instance is not associated to allocated
  *							isochronous resources.
- * @HINOKO_FW_ISO_RESOURCE_AUTO_ERROR_TIMEOUT:		No event to the request arrives within
- *							timeout.
  *
  * A set of error code for [class@FwIsoResourceAuto].
  */
@@ -91,7 +89,6 @@ typedef enum {
 	HINOKO_FW_ISO_RESOURCE_AUTO_ERROR_FAILED,
 	HINOKO_FW_ISO_RESOURCE_AUTO_ERROR_ALLOCATED,
 	HINOKO_FW_ISO_RESOURCE_AUTO_ERROR_NOT_ALLOCATED,
-	HINOKO_FW_ISO_RESOURCE_AUTO_ERROR_TIMEOUT,
 } HinokoFwIsoResourceAutoError;
 
 /**

--- a/src/internal.h
+++ b/src/internal.h
@@ -47,4 +47,19 @@ void hinoko_fw_iso_resource_auto_handle_event(HinokoFwIsoResourceAuto *self, gui
 					      guint bandwidth, const char *signal_name,
 					      const GError *error);
 
+struct fw_iso_resource_waiter {
+	GMutex mutex;
+	GCond cond;
+	GError *error;
+	gboolean handled;
+	guint64 expiration;
+	gulong handler_id;
+};
+
+void fw_iso_resource_waiter_init(HinokoFwIsoResource *self, struct fw_iso_resource_waiter *w,
+				 const char *signal_name, guint timeout_ms);
+
+void fw_iso_resource_waiter_wait(HinokoFwIsoResource *self, struct fw_iso_resource_waiter *w,
+				 GError **error);
+
 #endif

--- a/src/internal.h
+++ b/src/internal.h
@@ -43,7 +43,8 @@ void hinoko_fw_iso_resource_ioctl(HinokoFwIsoResource *self,
 				  unsigned long request, void *argp,
 				  GError **error);
 
-void hinoko_fw_iso_resource_auto_handle_event(HinokoFwIsoResourceAuto *self,
-					struct fw_cdev_event_iso_resource *ev);
+void hinoko_fw_iso_resource_auto_handle_event(HinokoFwIsoResourceAuto *self, guint channel,
+					      guint bandwidth, const char *signal_name,
+					      const GError *error);
 
 #endif

--- a/src/meson.build
+++ b/src/meson.build
@@ -14,6 +14,7 @@ sources = [
   'cycle_timer.c',
   'fw_iso_resource.c',
   'fw_iso_resource_auto.c',
+  'fw_iso_resource_once.c',
 ]
 
 headers = [
@@ -25,6 +26,7 @@ headers = [
   'cycle_timer.h',
   'fw_iso_resource.h',
   'fw_iso_resource_auto.h',
+  'fw_iso_resource_once.h',
   'hinoko_enum_types.h'
 ]
 

--- a/tests/fw-iso-resource
+++ b/tests/fw-iso-resource
@@ -16,10 +16,6 @@ methods = (
     'open',
     'create_source',
     'calculate_bandwidth',
-    'allocate_once_async',
-    'deallocate_once_async',
-    'allocate_once_sync',
-    'deallocate_once_sync',
 )
 vmethods = (
     'do_allocated',

--- a/tests/fw-iso-resource
+++ b/tests/fw-iso-resource
@@ -9,10 +9,9 @@ import gi
 gi.require_version('Hinoko', '0.0')
 from gi.repository import Hinoko
 
-target = Hinoko.FwIsoResource()
+target = Hinoko.FwIsoResource
 props = ()
 methods = (
-    'new',
     'open',
     'create_source',
     'calculate_bandwidth',

--- a/tests/fw-iso-resource-once
+++ b/tests/fw-iso-resource-once
@@ -1,0 +1,22 @@
+#!/usr/bin/env python3
+
+from sys import exit
+from errno import ENXIO
+
+from helper import test
+
+import gi
+gi.require_version('Hinoko', '0.0')
+from gi.repository import Hinoko
+
+target = Hinoko.FwIsoResourceOnce()
+props = ()
+methods = (
+    'new',
+)
+vmethods = ()
+signals = ()
+
+if not test(target, props, methods, vmethods, signals):
+    exit(ENXIO)
+

--- a/tests/fw-iso-resource-once
+++ b/tests/fw-iso-resource-once
@@ -13,6 +13,10 @@ target = Hinoko.FwIsoResourceOnce()
 props = ()
 methods = (
     'new',
+    'allocate_async',
+    'deallocate_async',
+    'allocate_sync',
+    'deallocate_sync',
 )
 vmethods = ()
 signals = ()

--- a/tests/hinoko-enum
+++ b/tests/hinoko-enum
@@ -43,7 +43,6 @@ fw_iso_resource_auto_error_enumerations = (
     'FAILED',
     'ALLOCATED',
     'NOT_ALLOCATED',
-    'TIMEOUT',
 )
 
 fw_iso_ctx_error_enumerations = (

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -6,6 +6,7 @@ tests = [
   'fw-iso-tx',
   'fw-iso-resource',
   'fw-iso-resource-auto',
+  'fw-iso-resource-once',
 ]
 
 envs = environment()


### PR DESCRIPTION
Current implementataion of Hinoko.FwIsoResource object includes functions
one-shot allocation/deallocation as well as basic functions for derived
objects. It's inconvenient in the derived object side.
    
This patchset adds Hinoko.FwIsoResourceOnce object for the one-shot functions,
then make Hinoko.FwIsoResource as abstract object.

Below public APIs are removed:

 * Hinoko.FwIsoResource.allocate_once_async
 * Hinoko.FwIsoResource.allocate_once_sync
 * Hinoko.FwIsoResource.deallocate_once_async
 * Hinoko.FwIsoResource.deallocate_once_sync

Below public APIs are added instead:

+   hinoko_fw_iso_resource_once_get_type
+   hinoko_fw_iso_resource_once_new
+   hinoko_fw_iso_resource_once_allocate_async
+   hinoko_fw_iso_resource_once_deallocate_async
+   hinoko_fw_iso_resource_once_allocate_sync
+   hinoko_fw_iso_resource_once_deallocate_sync

Furthermore, below public APIs are changed due to prototype change for
an additional parameter for timeout to wait for event.

+    hinoko_fw_iso_resource_auto_allocate_sync
+    hinoko_fw_iso_resource_auto_deallocate_sync


```
Takashi Sakamoto (9):
  fw_iso_resource_auto: fix name of inclusion guard
  fw_iso_ctx: fix constant GError annotation
  fw_iso_resource: fix GError override warning at error case
  fw_iso_resource: internal code refactoring to dispatch event
  fw_iso_resource: internal code refactoring for signal event waiter
  fw_iso_resource_auto: change public API to have timeout argument
  fw_iso_resource_once: add derived object to initiate allocation/deallocation by one shot
  fw_iso_resource_once: move public API for allocation/deallocation asynchronously/synchronously
  fw_iso_resource: make abstract object

 samples/iso-resource       |  10 +-
 src/fw_iso_ctx.c           |   2 +-
 src/fw_iso_ctx.h           |   2 +-
 src/fw_iso_resource.c      | 283 +++++++------------------------------
 src/fw_iso_resource.h      |  32 +----
 src/fw_iso_resource_auto.c | 116 ++++-----------
 src/fw_iso_resource_auto.h |   8 +-
 src/fw_iso_resource_once.c | 170 ++++++++++++++++++++++
 src/fw_iso_resource_once.h |  40 ++++++
 src/hinoko.h               |   1 +
 src/hinoko.map             |  20 ++-
 src/hinoko_enum_types.h    |   3 -
 src/internal.h             |  20 ++-
 src/meson.build            |   2 +
 tests/fw-iso-resource      |   7 +-
 tests/fw-iso-resource-once |  26 ++++
 tests/hinoko-enum          |   1 -
 tests/meson.build          |   1 +
 18 files changed, 364 insertions(+), 380 deletions(-)
 create mode 100644 src/fw_iso_resource_once.c
 create mode 100644 src/fw_iso_resource_once.h
 create mode 100644 tests/fw-iso-resource-once
```