### PR TITLE
[PATCH 0/6] fix minor bugs and clean up

### DIFF
--- a/src/fw_iso_ctx.h
+++ b/src/fw_iso_ctx.h
@@ -32,8 +32,7 @@ void hinoko_fw_iso_ctx_get_cycle_timer(HinokoFwIsoCtx *self, gint clock_id,
 				       HinokoCycleTimer *const *cycle_timer,
 				       GError **error);
 
-void hinoko_fw_iso_ctx_create_source(HinokoFwIsoCtx *self, GSource **gsrc,
-				     GError **error);
+void hinoko_fw_iso_ctx_create_source(HinokoFwIsoCtx *self, GSource **source, GError **error);
 
 void hinoko_fw_iso_ctx_flush_completions(HinokoFwIsoCtx *self, GError **error);
 

--- a/src/fw_iso_ctx.h
+++ b/src/fw_iso_ctx.h
@@ -20,7 +20,7 @@ struct _HinokoFwIsoCtxClass {
 	/**
 	 * HinokoFwIsoCtxClass::stopped:
 	 * @self: A [class@FwIsoCtx].
-	 * @error: (transfer none) (nullable): A [struct@GLib.Error].
+	 * @error: (transfer none) (nullable) (in): A [struct@GLib.Error].
 	 *
 	 * Class closure for the [signal@FwIsoCtx::stopped] signal.
 	 */

--- a/src/fw_iso_ctx_private.h
+++ b/src/fw_iso_ctx_private.h
@@ -7,6 +7,8 @@
 #include <unistd.h>
 #include <errno.h>
 
+#define STOPPED_SIGNAL_NEME		"stopped"
+
 void hinoko_fw_iso_ctx_allocate(HinokoFwIsoCtx *self, const char *path,
 				HinokoFwIsoCtxMode mode, HinokoFwScode scode,
 				guint channel, guint header_size,

--- a/src/fw_iso_ctx_private.h
+++ b/src/fw_iso_ctx_private.h
@@ -32,16 +32,13 @@ void hinoko_fw_iso_ctx_read_frames(HinokoFwIsoCtx *self, guint offset,
 				   guint length, const guint8 **frames,
 				   guint *frame_size);
 
-void hinoko_fw_iso_rx_single_handle_event(HinokoFwIsoRxSingle *self,
-				const struct fw_cdev_event_iso_interrupt *event,
-				GError **error);
+gboolean fw_iso_rx_single_handle_event(HinokoFwIsoCtx *inst, const union fw_cdev_event *event,
+				       GError **error);
 
-void hinoko_fw_iso_rx_multiple_handle_event(HinokoFwIsoRxMultiple *self,
-				const struct fw_cdev_event_iso_interrupt_mc *event,
-				GError **error);
+gboolean fw_iso_rx_multiple_handle_event(HinokoFwIsoCtx *inst, const union fw_cdev_event *event,
+					 GError **error);
 
-void hinoko_fw_iso_tx_handle_event(HinokoFwIsoTx *self,
-				   const struct fw_cdev_event_iso_interrupt *event,
-				   GError **error);
+gboolean fw_iso_tx_handle_event(HinokoFwIsoCtx *inst, const union fw_cdev_event *event,
+				GError **error);
 
 #endif

--- a/src/fw_iso_resource.c
+++ b/src/fw_iso_resource.c
@@ -39,7 +39,7 @@ static void hinoko_fw_iso_resource_default_init(HinokoFwIsoResourceInterface *if
 	 */
 	g_signal_new(ALLOCATED_SIGNAL_NAME,
 		     G_TYPE_FROM_INTERFACE(iface),
-		     G_SIGNAL_RUN_LAST,
+		     G_SIGNAL_RUN_LAST | G_SIGNAL_ACTION,
 		     G_STRUCT_OFFSET(HinokoFwIsoResourceInterface, allocated),
 		     NULL, NULL,
 		     hinoko_sigs_marshal_VOID__UINT_UINT_BOXED,
@@ -60,7 +60,7 @@ static void hinoko_fw_iso_resource_default_init(HinokoFwIsoResourceInterface *if
 	 */
 	g_signal_new(DEALLOCATED_SIGNAL_NAME,
 		     G_TYPE_FROM_INTERFACE(iface),
-		     G_SIGNAL_RUN_LAST,
+		     G_SIGNAL_RUN_LAST | G_SIGNAL_ACTION,
 		     G_STRUCT_OFFSET(HinokoFwIsoResourceInterface, deallocated),
 		     NULL, NULL,
 		     hinoko_sigs_marshal_VOID__UINT_UINT_BOXED,


### PR DESCRIPTION
This patchset fixes some bugs related to signal, including code cleanup.

```
Takashi Sakamoto (6):
  fw_iso_resource: add action flag for signals
  fw_iso_ctx: code refactoring for stopped signal
  fw_iso_ctx: code refactoring to add cache of file descriptor
  fw_iso_ctx: rename argument for convenience
  fw_iso_ctx: code refactoring to dispatch iso interrupt events
  fw_iso_ctx: code refactoring for event handler

 src/fw_iso_ctx.c         | 151 +++++++++++----------------
 src/fw_iso_ctx.h         |   5 +-
 src/fw_iso_ctx_private.h |  17 ++-
 src/fw_iso_resource.c    |   4 +-
 src/fw_iso_rx_multiple.c | 218 ++++++++++++++++++++-------------------
 src/fw_iso_rx_single.c   |  75 ++++++++------
 src/fw_iso_tx.c          |  32 +++---
 7 files changed, 247 insertions(+), 255 deletions(-)
```