### PR TITLE
[PATCH 0/7] fw_iso_resource: add property for bus generation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@
 libhinoko
 =========
 
-2022/05/04
+2022/05/05
 Takashi Sakamoto
 
 Introduction
@@ -133,6 +133,11 @@ wait for event:
 
 - ``Hinoko.FwIsoResourceAuto.allocate_sync``
 - ``Hinoko.FwIsoResourceAuto.deallocate_sync``
+
+Beside, below signal is newly added to express the value of current generation for the state of
+IEEE 1394 bus:
+
+- ``Hinoko.FwIsoResource::generation``
 
 Loss of backward compatibility between v0.5/v0.6 releases
 =========================================================

--- a/samples/iso-resource
+++ b/samples/iso-resource
@@ -21,7 +21,7 @@ th.start()
 def handle_event(res, channel, bandwidth, exception, ev_name):
     print('event:', ev_name)
     if exception is None:
-        print('  ', channel, bandwidth)
+        print('  ', channel, bandwidth, res.get_property('generation'))
     elif exception.matches(Hinoko.fw_iso_resource_error_quark(), Hinoko.FwIsoResourceError.EVENT):
         print('  ', exception)
 
@@ -43,7 +43,7 @@ for i in range(2):
             print(e)
     else:
         print('result: allocate')
-        print('  ', use_channel, use_bandwidth)
+        print('  ', use_channel, use_bandwidth, res.get_property('generation'))
 
     sleep(2)
 
@@ -54,7 +54,7 @@ for i in range(2):
             print(e)
     else:
         print('result: deallocate')
-        print('  ', use_channel, use_bandwidth)
+        print('  ', use_channel, use_bandwidth, res.get_property('generation'))
 
     sleep(2)
 
@@ -73,7 +73,7 @@ src = res.create_source()
 src.attach(ctx)
 
 def print_props(res):
-    for prop in ('is-allocated', 'channel', 'bandwidth'):
+    for prop in ('is-allocated', 'channel', 'bandwidth', 'generation'):
         print('  {}: {}'.format(prop, res.get_property(prop)))
 
 for i in range(2):

--- a/src/fw_iso_resource.c
+++ b/src/fw_iso_resource.c
@@ -26,6 +26,18 @@ G_DEFINE_QUARK(hinoko-fw-iso-resource-error-quark, hinoko_fw_iso_resource_error)
 static void hinoko_fw_iso_resource_default_init(HinokoFwIsoResourceInterface *iface)
 {
 	/**
+	 * HinokoFwIsoResource::generation:
+	 *
+	 * The numeric value of current generation for bus topology.
+	 */
+	g_object_interface_install_property(iface,
+		g_param_spec_uint(GENERATION_PROP_NAME, "generation",
+				  "The numeric value of current generation for bus topology",
+				  0, G_MAXUINT,
+				  0,
+				  G_PARAM_READABLE | G_PARAM_EXPLICIT_NOTIFY));
+
+	/**
 	 * HinokoFwIsoResource::allocated:
 	 * @self: A [iface@FwIsoResource].
 	 * @channel: The deallocated channel number.

--- a/src/fw_iso_resource_auto.c
+++ b/src/fw_iso_resource_auto.c
@@ -301,12 +301,10 @@ void hinoko_fw_iso_resource_auto_allocate_async(HinokoFwIsoResourceAuto *self,
 	}
 	res.bandwidth = bandwidth;
 
-	if (ioctl(priv->state.fd, FW_CDEV_IOC_ALLOCATE_ISO_RESOURCE, &res) < 0) {
-		generate_syscall_error(error, errno, "ioctl(%s)",
-				       "FW_CDEV_IOC_ALLOCATE_ISO_RESOURCE");
-	} else {
+	if (ioctl(priv->state.fd, FW_CDEV_IOC_ALLOCATE_ISO_RESOURCE, &res) < 0)
+		generate_ioctl_error(error, errno, FW_CDEV_IOC_ALLOCATE_ISO_RESOURCE);
+	else
 		priv->handle = res.handle;
-	}
 end:
 	g_mutex_unlock(&priv->mutex);
 }
@@ -340,10 +338,8 @@ void hinoko_fw_iso_resource_auto_deallocate_async(HinokoFwIsoResourceAuto *self,
 
 	dealloc.handle = priv->handle;
 
-	if (ioctl(priv->state.fd, FW_CDEV_IOC_DEALLOCATE_ISO_RESOURCE, &dealloc) < 0) {
-		generate_syscall_error(error, errno, "ioctl(%s)",
-				       "FW_CDEV_IOC_DEALLOCATE_ISO_RESOURCE");
-	}
+	if (ioctl(priv->state.fd, FW_CDEV_IOC_DEALLOCATE_ISO_RESOURCE, &dealloc) < 0)
+		generate_ioctl_error(error, errno, FW_CDEV_IOC_DEALLOCATE_ISO_RESOURCE);
 end:
 	g_mutex_unlock(&priv->mutex);
 }

--- a/src/fw_iso_resource_auto.c
+++ b/src/fw_iso_resource_auto.c
@@ -183,6 +183,15 @@ static void handle_iso_resource_event(HinokoFwIsoResourceAuto *self,
 		g_clear_error(&error);
 }
 
+static void handle_bus_reset_event(HinokoFwIsoResourceAuto *self,
+				   const struct fw_cdev_event_bus_reset *ev)
+{
+	HinokoFwIsoResourceAutoPrivate *priv =
+		hinoko_fw_iso_resource_auto_get_instance_private(self);
+
+	memcpy(&priv->state.bus_state, ev, sizeof(*ev));
+}
+
 void fw_iso_resource_auto_handle_event(HinokoFwIsoResource *inst, const union fw_cdev_event *event)
 {
 	HinokoFwIsoResourceAuto *self;
@@ -194,6 +203,9 @@ void fw_iso_resource_auto_handle_event(HinokoFwIsoResource *inst, const union fw
 	case FW_CDEV_EVENT_ISO_RESOURCE_ALLOCATED:
 	case FW_CDEV_EVENT_ISO_RESOURCE_DEALLOCATED:
 		handle_iso_resource_event(self, &event->iso_resource);
+		break;
+	case FW_CDEV_EVENT_BUS_RESET:
+		handle_bus_reset_event(self, &event->bus_reset);
 		break;
 	default:
 		break;

--- a/src/fw_iso_resource_auto.c
+++ b/src/fw_iso_resource_auto.c
@@ -283,6 +283,10 @@ void hinoko_fw_iso_resource_auto_allocate_async(HinokoFwIsoResourceAuto *self,
 	g_return_if_fail(error == NULL || *error == NULL);
 
 	priv = hinoko_fw_iso_resource_auto_get_instance_private(self);
+	if (priv->state.fd < 0) {
+		generate_coded_error(error, HINOKO_FW_ISO_RESOURCE_ERROR_NOT_OPENED);
+		return;
+	}
 
 	g_return_if_fail(channel_candidates != NULL);
 	g_return_if_fail(channel_candidates_count > 0);
@@ -328,6 +332,10 @@ void hinoko_fw_iso_resource_auto_deallocate_async(HinokoFwIsoResourceAuto *self,
 	g_return_if_fail(error == NULL || *error == NULL);
 
 	priv = hinoko_fw_iso_resource_auto_get_instance_private(self);
+	if (priv->state.fd < 0) {
+		generate_coded_error(error, HINOKO_FW_ISO_RESOURCE_ERROR_NOT_OPENED);
+		return;
+	}
 
 	g_mutex_lock(&priv->mutex);
 

--- a/src/fw_iso_resource_once.c
+++ b/src/fw_iso_resource_once.c
@@ -75,6 +75,15 @@ static void handle_iso_resource_event(HinokoFwIsoResourceOnce *self,
 		g_clear_error(&error);
 }
 
+static void handle_bus_reset_event(HinokoFwIsoResourceOnce *self,
+				   const struct fw_cdev_event_bus_reset *ev)
+{
+	HinokoFwIsoResourceOncePrivate *priv =
+		hinoko_fw_iso_resource_once_get_instance_private(self);
+
+	memcpy(&priv->state.bus_state, ev, sizeof(*ev));
+}
+
 void fw_iso_resource_once_handle_event(HinokoFwIsoResource *inst, const union fw_cdev_event *event)
 {
 	HinokoFwIsoResourceOnce *self;
@@ -86,6 +95,9 @@ void fw_iso_resource_once_handle_event(HinokoFwIsoResource *inst, const union fw
 	case FW_CDEV_EVENT_ISO_RESOURCE_ALLOCATED:
 	case FW_CDEV_EVENT_ISO_RESOURCE_DEALLOCATED:
 		handle_iso_resource_event(self, &event->iso_resource);
+		break;
+	case FW_CDEV_EVENT_BUS_RESET:
+		handle_bus_reset_event(self, &event->bus_reset);
 		break;
 	default:
 		break;

--- a/src/fw_iso_resource_once.c
+++ b/src/fw_iso_resource_once.c
@@ -203,10 +203,8 @@ void hinoko_fw_iso_resource_once_allocate_async(HinokoFwIsoResourceOnce *self,
 	}
 	res.bandwidth = bandwidth;
 
-	if (ioctl(priv->state.fd, FW_CDEV_IOC_ALLOCATE_ISO_RESOURCE_ONCE, &res) < 0) {
-		generate_syscall_error(error, errno, "ioctl(%s)",
-				       "FW_CDEV_IOC_ALLOCATE_ISO_RESOURCE_ONCE");
-	}
+	if (ioctl(priv->state.fd, FW_CDEV_IOC_ALLOCATE_ISO_RESOURCE_ONCE, &res) < 0)
+		generate_ioctl_error(error, errno, FW_CDEV_IOC_ALLOCATE_ISO_RESOURCE_ONCE);
 }
 
 /**
@@ -240,10 +238,8 @@ void hinoko_fw_iso_resource_once_deallocate_async(HinokoFwIsoResourceOnce *self,
 	res.channels = 1ull << channel;
 	res.bandwidth = bandwidth;
 
-	if (ioctl(priv->state.fd, FW_CDEV_IOC_DEALLOCATE_ISO_RESOURCE_ONCE, &res) < 0) {
-		generate_syscall_error(error, errno, "ioctl(%s)",
-				       "FW_CDEV_IOC_DEALLOCATE_ISO_RESOURCE_ONCE");
-	}
+	if (ioctl(priv->state.fd, FW_CDEV_IOC_DEALLOCATE_ISO_RESOURCE_ONCE, &res) < 0)
+		generate_ioctl_error(error, errno, FW_CDEV_IOC_DEALLOCATE_ISO_RESOURCE_ONCE);
 }
 
 /**

--- a/src/fw_iso_resource_once.c
+++ b/src/fw_iso_resource_once.c
@@ -196,6 +196,10 @@ void hinoko_fw_iso_resource_once_allocate_async(HinokoFwIsoResourceOnce *self,
 	g_return_if_fail(bandwidth > 0);
 
 	priv = hinoko_fw_iso_resource_once_get_instance_private(self);
+	if (priv->state.fd < 0) {
+		generate_coded_error(error, HINOKO_FW_ISO_RESOURCE_ERROR_NOT_OPENED);
+		return;
+	}
 
 	for (i = 0; i < channel_candidates_count; ++i) {
 		if (channel_candidates[i] < 64)
@@ -234,6 +238,10 @@ void hinoko_fw_iso_resource_once_deallocate_async(HinokoFwIsoResourceOnce *self,
 	g_return_if_fail(bandwidth > 0);
 
 	priv = hinoko_fw_iso_resource_once_get_instance_private(self);
+	if (priv->state.fd < 0) {
+		generate_coded_error(error, HINOKO_FW_ISO_RESOURCE_ERROR_NOT_OPENED);
+		return;
+	}
 
 	res.channels = 1ull << channel;
 	res.bandwidth = bandwidth;

--- a/src/fw_iso_resource_private.c
+++ b/src/fw_iso_resource_private.c
@@ -200,7 +200,7 @@ gboolean fw_iso_resource_state_cache_bus_state(struct fw_iso_resource_state *sta
 	get_info.bus_reset = (__u64)&state->bus_state;
 
 	if (ioctl(state->fd, FW_CDEV_IOC_GET_INFO, &get_info) < 0) {
-		generate_syscall_error(error, errno, "ioctl(%s)", "FW_CDEV_IOC_GET_INFO");
+		generate_ioctl_error(error, errno, FW_CDEV_IOC_GET_INFO);
 		return FALSE;
 	}
 

--- a/src/fw_iso_resource_private.c
+++ b/src/fw_iso_resource_private.c
@@ -35,6 +35,25 @@ typedef struct {
 	void (*handle_event)(HinokoFwIsoResource *self, const union fw_cdev_event *event);
 } FwIsoResourceSource;
 
+void fw_iso_resource_class_override_properties(GObjectClass *gobject_class)
+{
+	g_object_class_override_property(gobject_class, FW_ISO_RESOURCE_PROP_TYPE_GENERATION,
+					 GENERATION_PROP_NAME);
+}
+
+void fw_iso_resource_state_get_property(const struct fw_iso_resource_state *state, GObject *obj,
+					guint id, GValue *val, GParamSpec *spec)
+{
+	switch (id) {
+	case FW_ISO_RESOURCE_PROP_TYPE_GENERATION:
+		g_value_set_uint(val, state->bus_state.generation);
+		break;
+	default:
+		G_OBJECT_WARN_INVALID_PROPERTY_ID(obj, id, spec);
+		break;
+	}
+}
+
 void fw_iso_resource_state_init(struct fw_iso_resource_state *state)
 {
 	state->fd = -1;

--- a/src/fw_iso_resource_private.h
+++ b/src/fw_iso_resource_private.h
@@ -18,6 +18,9 @@
 		    HINOKO_FW_ISO_RESOURCE_ERROR_FAILED,		\
 		    format " %d(%s)", arg, errno, strerror(errno))
 
+#define generate_ioctl_error(error, errno, request)			\
+	generate_syscall_error(error, errno, "ioctl(%s)", #request)
+
 struct fw_iso_resource_state {
 	int fd;
 	struct fw_cdev_event_bus_reset bus_state;

--- a/src/fw_iso_resource_private.h
+++ b/src/fw_iso_resource_private.h
@@ -16,12 +16,22 @@
 		    HINOKO_FW_ISO_RESOURCE_ERROR_FAILED,		\
 		    format " %d(%s)", arg, errno, strerror(errno))
 
-gboolean fw_iso_resource_open(int *fd, const gchar *path, gint open_flag, GError **error);
+struct fw_iso_resource_state {
+	int fd;
+};
 
-gboolean fw_iso_resource_create_source(int fd, HinokoFwIsoResource *inst,
-				       void (*handle_event)(HinokoFwIsoResource *self,
-							    const union fw_cdev_event *event),
-				       GSource **source, GError **error);
+void fw_iso_resource_state_init(struct fw_iso_resource_state *state);
+
+void fw_iso_resource_state_release(struct fw_iso_resource_state *state);
+
+gboolean fw_iso_resource_state_open(struct fw_iso_resource_state *state, const gchar *path,
+				    gint open_flag, GError **error);
+
+gboolean fw_iso_resource_state_create_source(struct fw_iso_resource_state *state,
+					     HinokoFwIsoResource *inst,
+					     void (*handle_event)(HinokoFwIsoResource *self,
+								  const union fw_cdev_event *event),
+					     GSource **source, GError **error);
 
 struct fw_iso_resource_waiter {
 	GMutex mutex;

--- a/src/fw_iso_resource_private.h
+++ b/src/fw_iso_resource_private.h
@@ -13,6 +13,12 @@
 #define ALLOCATED_SIGNAL_NAME		"allocated"
 #define DEALLOCATED_SIGNAL_NAME		"deallocated"
 
+extern const char *const fw_iso_resource_err_msgs[HINOKO_FW_ISO_RESOURCE_ERROR_EVENT + 1];
+
+#define generate_coded_error(error, code) 				\
+	g_set_error_literal(error, HINOKO_FW_ISO_RESOURCE_ERROR, code,	\
+			    fw_iso_resource_err_msgs[code])
+
 #define generate_syscall_error(error, errno, format, arg)		\
 	g_set_error(error, HINOKO_FW_ISO_RESOURCE_ERROR,		\
 		    HINOKO_FW_ISO_RESOURCE_ERROR_FAILED,		\

--- a/src/fw_iso_resource_private.h
+++ b/src/fw_iso_resource_private.h
@@ -8,6 +8,8 @@
 #include <errno.h>
 #include <sys/ioctl.h>
 
+#define GENERATION_PROP_NAME		"generation"
+
 #define ALLOCATED_SIGNAL_NAME		"allocated"
 #define DEALLOCATED_SIGNAL_NAME		"deallocated"
 
@@ -20,6 +22,16 @@ struct fw_iso_resource_state {
 	int fd;
 	struct fw_cdev_event_bus_reset bus_state;
 };
+
+enum fw_iso_resource_prop_type {
+	FW_ISO_RESOURCE_PROP_TYPE_GENERATION = 1,
+	FW_ISO_RESOURCE_PROP_TYPE_COUNT,
+};
+
+void fw_iso_resource_class_override_properties(GObjectClass *gobject_class);
+
+void fw_iso_resource_state_get_property(const struct fw_iso_resource_state *state, GObject *obj,
+					guint id, GValue *val, GParamSpec *spec);
 
 void fw_iso_resource_state_init(struct fw_iso_resource_state *state);
 

--- a/src/fw_iso_resource_private.h
+++ b/src/fw_iso_resource_private.h
@@ -20,8 +20,7 @@ gboolean fw_iso_resource_open(int *fd, const gchar *path, gint open_flag, GError
 
 gboolean fw_iso_resource_create_source(int fd, HinokoFwIsoResource *inst,
 				       void (*handle_event)(HinokoFwIsoResource *self,
-							    const char *signal_name, guint channel,
-							    guint bandwidth, const GError *error),
+							    const union fw_cdev_event *event),
 				       GSource **source, GError **error);
 
 struct fw_iso_resource_waiter {
@@ -38,5 +37,8 @@ void fw_iso_resource_waiter_init(struct fw_iso_resource_waiter *w, HinokoFwIsoRe
 
 void fw_iso_resource_waiter_wait(struct fw_iso_resource_waiter *w, HinokoFwIsoResource *self,
 				 GError **error);
+
+void parse_iso_resource_event(const struct fw_cdev_event_iso_resource *ev, guint *channel,
+			      guint *bandwidth, const char **signal_name, GError **error);
 
 #endif

--- a/src/fw_iso_resource_private.h
+++ b/src/fw_iso_resource_private.h
@@ -18,6 +18,7 @@
 
 struct fw_iso_resource_state {
 	int fd;
+	struct fw_cdev_event_bus_reset bus_state;
 };
 
 void fw_iso_resource_state_init(struct fw_iso_resource_state *state);
@@ -32,6 +33,8 @@ gboolean fw_iso_resource_state_create_source(struct fw_iso_resource_state *state
 					     void (*handle_event)(HinokoFwIsoResource *self,
 								  const union fw_cdev_event *event),
 					     GSource **source, GError **error);
+
+gboolean fw_iso_resource_state_cache_bus_state(struct fw_iso_resource_state *state, GError **error);
 
 struct fw_iso_resource_waiter {
 	GMutex mutex;

--- a/tests/fw-iso-resource-auto
+++ b/tests/fw-iso-resource-auto
@@ -14,6 +14,7 @@ props = (
     'is-allocated',
     'channel',
     'bandwidth',
+    'generation',
 )
 methods = (
     'new',

--- a/tests/fw-iso-resource-once
+++ b/tests/fw-iso-resource-once
@@ -10,7 +10,9 @@ gi.require_version('Hinoko', '0.0')
 from gi.repository import Hinoko
 
 target = Hinoko.FwIsoResourceOnce()
-props = ()
+props = (
+    'generation',
+)
 methods = (
     'new',
     'open',


### PR DESCRIPTION
`Hinoko.FwIsoResourceOnce` operates isochronous resource bound to current
generation of IEEE 1394 bus, therefore it's convenient to have the way to check
current generation of IEEE 1394 bus.

This patchset adds a property to `Hinoko.FwIsoResource` so that the property
expresses current generation of IEEE 1394 bus. The property is explicitly
updated when IEEE 1394 bus gets bus reset.

```
Takashi Sakamoto (7):
  fw_iso_resource: code refactoring to handle several types of event
  fw_iso_resource_private: add structure to maintain state
  fw_iso_resource: handle event of bus reset
  fw_iso_ctx: add generation property
  fw_iso_ctx_private: code refactoring for error generation macro of ioctl
  fw_iso_ctx_private: code refactoring for coded error
  update README

 README.rst                    |   7 +-
 samples/iso-resource          |   8 +-
 src/fw_iso_resource.c         |  12 +++
 src/fw_iso_resource_auto.c    | 141 ++++++++++++++++++++++----------
 src/fw_iso_resource_once.c    | 103 +++++++++++++++++++----
 src/fw_iso_resource_private.c | 150 ++++++++++++++++++++++------------
 src/fw_iso_resource_private.h |  48 +++++++++--
 tests/fw-iso-resource-auto    |   1 +
 tests/fw-iso-resource-once    |   4 +-
 9 files changed, 349 insertions(+), 125 deletions(-)
```