### PR TITLE
[PATCH 00/10] rewrite public API according to convention of GNOME project

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -139,6 +139,10 @@ IEEE 1394 bus:
 
 - ``Hinoko.FwIsoResource::generation``
 
+In GNOME convention, the throw function to report error at GError argument should return gboolean
+value to report the overall operation finishes successfully or not. At v0.7, the most of public
+API are rewritten according to it.
+
 Loss of backward compatibility between v0.5/v0.6 releases
 =========================================================
 

--- a/samples/iso-resource
+++ b/samples/iso-resource
@@ -32,7 +32,7 @@ res.open('/dev/fw0', 0)
 res.connect('allocated', handle_event, 'allocated')
 res.connect('deallocated', handle_event, 'deallocated')
 
-src = res.create_source()
+_, src = res.create_source()
 src.attach(ctx)
 
 for i in range(2):
@@ -69,7 +69,7 @@ res.open('/dev/fw0', 0)
 res.connect('allocated', handle_event, 'allocated')
 res.connect('deallocated', handle_event, 'deallocated')
 
-src = res.create_source()
+_, src = res.create_source()
 src.attach(ctx)
 
 def print_props(res):

--- a/samples/iso-rx-multiple
+++ b/samples/iso-rx-multiple
@@ -24,7 +24,7 @@ class IsoRxMultiple(Hinoko.FwIsoRxMultiple):
         self.release()
 
     def begin(self, dispatcher, duration):
-        self.__src = self.create_source()
+        _, self.__src = self.create_source()
         self.__src.attach(dispatcher.get_context())
         self.__dispatcher = dispatcher
 

--- a/samples/iso-rx-single
+++ b/samples/iso-rx-single
@@ -30,7 +30,7 @@ class IsoRxSingle(Hinoko.FwIsoRxSingle):
         self.register_packet(schedule_interrupt)
 
     def begin(self, dispatcher, duration):
-        self.__src = self.create_source()
+        _, self.__src = self.create_source()
         self.__src.attach(dispatcher.get_context())
         self.__dispatcher = dispatcher
 
@@ -46,7 +46,7 @@ class IsoRxSingle(Hinoko.FwIsoRxSingle):
         # Start one half of second later. Scheduling is available with lower 2 bits of second field.
         cycle_timer = Hinoko.CycleTimer.new()
         clock_id = 4    #CLOCK_MONOTONIC_RAW
-        cycle_timer = self.get_cycle_timer(clock_id, cycle_timer)
+        _, cycle_timer = self.get_cycle_timer(clock_id, cycle_timer)
         (sec, cycle, tick) = cycle_timer.get_cycle_timer()
         sec, cycle = self.__increment_cycle(sec, cycle, 4000)
         cycle_match = (sec & 0x3, cycle)

--- a/samples/iso-tx
+++ b/samples/iso-tx
@@ -35,7 +35,7 @@ class IsoTx(Hinoko.FwIsoTx):
         self.register_packet(self.tag, self.sy, cip_header, cip_payload, schedule_interrupt)
 
     def begin(self, dispatcher, packets_per_interrupt, duration):
-        self.__src = self.create_source()
+        _, self.__src = self.create_source()
         self.__src.attach(dispatcher.get_context())
         self.__dispatcher = dispatcher
 
@@ -49,7 +49,7 @@ class IsoTx(Hinoko.FwIsoTx):
         # Start 100 msec later. Scheduling is available with lower 2 bits of second field.
         cycle_timer = Hinoko.CycleTimer.new()
         clock_id = 4    # CLOCK_MONOTONIC_RAW
-        cycle_timer = self.get_cycle_timer(clock_id, cycle_timer)
+        _, cycle_timer = self.get_cycle_timer(clock_id, cycle_timer)
         (sec, cycle, tick) = cycle_timer.get_cycle_timer()
         sec, cycle = self.__increment_cycle(sec, cycle, 800)
         cycle_match = (sec & 0x3, cycle)

--- a/src/fw_iso_ctx.c
+++ b/src/fw_iso_ctx.c
@@ -63,16 +63,19 @@ static void hinoko_fw_iso_ctx_default_init(HinokoFwIsoCtxInterface *iface)
  *
  * Retrieve the value of cycle timer register. This method call is available
  * once any isochronous context is created.
+ *
+ * Returns: TRUE if the overall operation finishes successfully, else FALSE.
+ *
+ * Since: 0.7.
  */
-void hinoko_fw_iso_ctx_get_cycle_timer(HinokoFwIsoCtx *self, gint clock_id,
-				       HinokoCycleTimer *const *cycle_timer,
-				       GError **error)
+gboolean hinoko_fw_iso_ctx_get_cycle_timer(HinokoFwIsoCtx *self, gint clock_id,
+					   HinokoCycleTimer *const *cycle_timer, GError **error)
 {
-	g_return_if_fail(HINOKO_IS_FW_ISO_CTX(self));
-	g_return_if_fail(cycle_timer != NULL);
-	g_return_if_fail(error == NULL || *error == NULL);
+	g_return_val_if_fail(HINOKO_IS_FW_ISO_CTX(self), FALSE);
+	g_return_val_if_fail(cycle_timer != NULL, FALSE);
+	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
 
-	HINOKO_FW_ISO_CTX_GET_IFACE(self)->get_cycle_timer(self, clock_id, cycle_timer, error);
+	return HINOKO_FW_ISO_CTX_GET_IFACE(self)->get_cycle_timer(self, clock_id, cycle_timer, error);
 }
 
 /**
@@ -83,14 +86,18 @@ void hinoko_fw_iso_ctx_get_cycle_timer(HinokoFwIsoCtx *self, gint clock_id,
  *
  * Create [struct@GLib.Source] for [struct@GLib.MainContext] to dispatch events for isochronous
  * context.
+ *
+ * Returns: TRUE if the overall operation finishes successfully, else FALSE.
+ *
+ * Since: 0.7.
  */
-void hinoko_fw_iso_ctx_create_source(HinokoFwIsoCtx *self, GSource **source, GError **error)
+gboolean hinoko_fw_iso_ctx_create_source(HinokoFwIsoCtx *self, GSource **source, GError **error)
 {
-	g_return_if_fail(HINOKO_IS_FW_ISO_CTX(self));
-	g_return_if_fail(source != NULL);
-	g_return_if_fail(error == NULL || *error == NULL);
+	g_return_val_if_fail(HINOKO_IS_FW_ISO_CTX(self), FALSE);
+	g_return_val_if_fail(source != NULL, FALSE);
+	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
 
-	(void)HINOKO_FW_ISO_CTX_GET_IFACE(self)->create_source(self, source, error);
+	return HINOKO_FW_ISO_CTX_GET_IFACE(self)->create_source(self, source, error);
 }
 
 /**
@@ -149,12 +156,14 @@ void hinoko_fw_iso_ctx_release(HinokoFwIsoCtx *self)
  * context to queue any type of interrupt event for the recent isochronous cycle. Application can
  * process the content of isochronous packet without waiting for actual hardware interrupt.
  *
- * Since: 0.6.
+ * Returns: TRUE if the overall operation finishes successfully, else FALSE.
+ *
+ * Since: 0.7.
  */
-void hinoko_fw_iso_ctx_flush_completions(HinokoFwIsoCtx *self, GError **error)
+gboolean hinoko_fw_iso_ctx_flush_completions(HinokoFwIsoCtx *self, GError **error)
 {
-	g_return_if_fail(HINOKO_IS_FW_ISO_CTX(self));
-	g_return_if_fail(error == NULL || *error == NULL);
+	g_return_val_if_fail(HINOKO_IS_FW_ISO_CTX(self), FALSE);
+	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
 
-	(void)HINOKO_FW_ISO_CTX_GET_IFACE(self)->flush_completions(self, error);
+	return HINOKO_FW_ISO_CTX_GET_IFACE(self)->flush_completions(self, error);
 }

--- a/src/fw_iso_ctx.h
+++ b/src/fw_iso_ctx.h
@@ -46,13 +46,12 @@ void hinoko_fw_iso_ctx_unmap_buffer(HinokoFwIsoCtx *self);
 
 void hinoko_fw_iso_ctx_release(HinokoFwIsoCtx *self);
 
-void hinoko_fw_iso_ctx_get_cycle_timer(HinokoFwIsoCtx *self, gint clock_id,
-				       HinokoCycleTimer *const *cycle_timer,
-				       GError **error);
+gboolean hinoko_fw_iso_ctx_get_cycle_timer(HinokoFwIsoCtx *self, gint clock_id,
+					   HinokoCycleTimer *const *cycle_timer, GError **error);
 
-void hinoko_fw_iso_ctx_create_source(HinokoFwIsoCtx *self, GSource **source, GError **error);
+gboolean hinoko_fw_iso_ctx_create_source(HinokoFwIsoCtx *self, GSource **source, GError **error);
 
-void hinoko_fw_iso_ctx_flush_completions(HinokoFwIsoCtx *self, GError **error);
+gboolean hinoko_fw_iso_ctx_flush_completions(HinokoFwIsoCtx *self, GError **error);
 
 G_END_DECLS
 

--- a/src/fw_iso_ctx_private.c
+++ b/src/fw_iso_ctx_private.c
@@ -570,6 +570,8 @@ void fw_iso_ctx_state_read_frame(struct fw_iso_ctx_state *state, guint offset, g
  * Flush isochronous context until recent isochronous cycle. The call of function forces the
  * context to queue any type of interrupt event for the recent isochronous cycle. Application can
  * process the content of isochronous packet without waiting for actual hardware interrupt.
+ *
+ * Returns: TRUE if the overall operation finishes successfully, else FALSE.
  */
 gboolean fw_iso_ctx_state_flush_completions(struct fw_iso_ctx_state *state, GError **error)
 {
@@ -591,6 +593,8 @@ gboolean fw_iso_ctx_state_flush_completions(struct fw_iso_ctx_state *state, GErr
  *
  * Retrieve the value of cycle timer register. This method call is available
  * once any isochronous context is created.
+ *
+ * Returns: TRUE if the overall operation finishes successfully, else FALSE.
  */
 gboolean fw_iso_ctx_state_get_cycle_timer(struct fw_iso_ctx_state *state, gint clock_id,
 					  HinokoCycleTimer *const *cycle_timer, GError **error)
@@ -674,6 +678,8 @@ static void finalize_src(GSource *source)
  *
  * Create [struct@GLib.Source] for [struct@GLib.MainContext] to dispatch events for isochronous
  * context.
+ *
+ * Returns: TRUE if the overall operation finishes successfully, else FALSE.
  */
 gboolean fw_iso_ctx_state_create_source(struct fw_iso_ctx_state *state, HinokoFwIsoCtx *inst,
 					gboolean (*handle_event)(HinokoFwIsoCtx *inst,

--- a/src/fw_iso_resource.c
+++ b/src/fw_iso_resource.c
@@ -92,16 +92,18 @@ static void hinoko_fw_iso_resource_default_init(HinokoFwIsoResourceInterface *if
  * Open Linux FireWire character device to delegate any request for isochronous
  * resource management to Linux FireWire subsystem.
  *
+ * Returns: TRUE if the overall operation finished successfully, else FALSE.
+ *
  * Since: 0.7.
  */
-void hinoko_fw_iso_resource_open(HinokoFwIsoResource *self, const gchar *path, gint open_flag,
-				 GError **error)
+gboolean hinoko_fw_iso_resource_open(HinokoFwIsoResource *self, const gchar *path, gint open_flag,
+				     GError **error)
 {
-	g_return_if_fail(HINOKO_IS_FW_ISO_RESOURCE(self));
-	g_return_if_fail(path != NULL && strlen(path) > 0);
-	g_return_if_fail(error == NULL || *error == NULL);
+	g_return_val_if_fail(HINOKO_IS_FW_ISO_RESOURCE(self), FALSE);
+	g_return_val_if_fail(path != NULL && strlen(path) > 0, FALSE);
+	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
 
-	(void)HINOKO_FW_ISO_RESOURCE_GET_IFACE(self)->open(self, path, open_flag, error);
+	return HINOKO_FW_ISO_RESOURCE_GET_IFACE(self)->open(self, path, open_flag, error);
 }
 
 /**
@@ -113,16 +115,18 @@ void hinoko_fw_iso_resource_open(HinokoFwIsoResource *self, const gchar *path, g
  * Create [struct@GLib.Source] for [struct@GLib.MainContext] to dispatch events for isochronous
  * resource.
  *
+ * Returns: TRUE if the overall operation finished successfully, else FALSE.
+ *
  * Since: 0.7.
  */
-void hinoko_fw_iso_resource_create_source(HinokoFwIsoResource *self, GSource **source,
-					  GError **error)
+gboolean hinoko_fw_iso_resource_create_source(HinokoFwIsoResource *self, GSource **source,
+					      GError **error)
 {
-	g_return_if_fail(HINOKO_IS_FW_ISO_RESOURCE(self));
-	g_return_if_fail(source != NULL);
-	g_return_if_fail(error == NULL || *error == NULL);
+	g_return_val_if_fail(HINOKO_IS_FW_ISO_RESOURCE(self), FALSE);
+	g_return_val_if_fail(source != NULL, FALSE);
+	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
 
-	(void)HINOKO_FW_ISO_RESOURCE_GET_IFACE(self)->create_source(self, source, error);
+	return HINOKO_FW_ISO_RESOURCE_GET_IFACE(self)->create_source(self, source, error);
 }
 
 /**

--- a/src/fw_iso_resource.h
+++ b/src/fw_iso_resource.h
@@ -53,11 +53,11 @@ struct _HinokoFwIsoResourceInterface {
 			    guint bandwidth, const GError *error);
 };
 
-void hinoko_fw_iso_resource_open(HinokoFwIsoResource *self, const gchar *path,
-				 gint open_flag, GError **error);
+gboolean hinoko_fw_iso_resource_open(HinokoFwIsoResource *self, const gchar *path, gint open_flag,
+				     GError **error);
 
-void hinoko_fw_iso_resource_create_source(HinokoFwIsoResource *self,
-					  GSource **source, GError **error);
+gboolean hinoko_fw_iso_resource_create_source(HinokoFwIsoResource *self, GSource **source,
+					      GError **error);
 
 guint hinoko_fw_iso_resource_calculate_bandwidth(guint bytes_per_payload,
 						 HinokoFwScode scode);

--- a/src/fw_iso_resource_auto.h
+++ b/src/fw_iso_resource_auto.h
@@ -19,23 +19,23 @@ struct _HinokoFwIsoResourceAutoClass {
 	GObjectClass parent_class;
 };
 
-HinokoFwIsoResourceAuto *hinoko_fw_iso_resource_auto_new();
+HinokoFwIsoResourceAuto *hinoko_fw_iso_resource_auto_new(void);
 
-void hinoko_fw_iso_resource_auto_allocate_async(HinokoFwIsoResourceAuto *self,
-						guint8 *channel_candidates,
-						gsize channel_candidates_count,
-						guint bandwidth,
-						GError **error);
-void hinoko_fw_iso_resource_auto_allocate_sync(HinokoFwIsoResourceAuto *self,
-					       guint8 *channel_candidates,
-					       gsize channel_candidates_count,
-					       guint bandwidth, guint timeout_ms,
-					       GError **error);
+gboolean hinoko_fw_iso_resource_auto_allocate_async(HinokoFwIsoResourceAuto *self,
+						    guint8 *channel_candidates,
+						    gsize channel_candidates_count,
+						    guint bandwidth,
+						    GError **error);
+gboolean hinoko_fw_iso_resource_auto_allocate_sync(HinokoFwIsoResourceAuto *self,
+					           guint8 *channel_candidates,
+					           gsize channel_candidates_count,
+					           guint bandwidth, guint timeout_ms,
+					           GError **error);
 
-void hinoko_fw_iso_resource_auto_deallocate_async(HinokoFwIsoResourceAuto *self,
-						  GError **error);
-void hinoko_fw_iso_resource_auto_deallocate_sync(HinokoFwIsoResourceAuto *self, guint timeout_ms,
-						 GError **error);
+gboolean hinoko_fw_iso_resource_auto_deallocate_async(HinokoFwIsoResourceAuto *self,
+						      GError **error);
+gboolean hinoko_fw_iso_resource_auto_deallocate_sync(HinokoFwIsoResourceAuto *self,
+						     guint timeout_ms, GError **error);
 
 G_END_DECLS
 

--- a/src/fw_iso_resource_once.c
+++ b/src/fw_iso_resource_once.c
@@ -282,7 +282,7 @@ void hinoko_fw_iso_resource_once_allocate_sync(HinokoFwIsoResourceOnce *self,
 	hinoko_fw_iso_resource_once_allocate_async(self, channel_candidates,
 						   channel_candidates_count, bandwidth, error);
 
-	fw_iso_resource_waiter_wait(&w, HINOKO_FW_ISO_RESOURCE(self), error);
+	(void)fw_iso_resource_waiter_wait(&w, HINOKO_FW_ISO_RESOURCE(self), error);
 }
 
 /**
@@ -312,5 +312,5 @@ void hinoko_fw_iso_resource_once_deallocate_sync(HinokoFwIsoResourceOnce *self, 
 
 	hinoko_fw_iso_resource_once_deallocate_async(self, channel, bandwidth, error);
 
-	fw_iso_resource_waiter_wait(&w, HINOKO_FW_ISO_RESOURCE(self), error);
+	(void)fw_iso_resource_waiter_wait(&w, HINOKO_FW_ISO_RESOURCE(self), error);
 }

--- a/src/fw_iso_resource_once.h
+++ b/src/fw_iso_resource_once.h
@@ -17,23 +17,23 @@ struct _HinokoFwIsoResourceOnceClass {
 
 HinokoFwIsoResourceOnce *hinoko_fw_iso_resource_once_new();
 
-void hinoko_fw_iso_resource_once_allocate_async(HinokoFwIsoResourceOnce *self,
-						guint8 *channel_candidates,
-						gsize channel_candidates_count,
-						guint bandwidth, GError **error);
+gboolean hinoko_fw_iso_resource_once_allocate_async(HinokoFwIsoResourceOnce *self,
+						    guint8 *channel_candidates,
+						    gsize channel_candidates_count,
+						    guint bandwidth, GError **error);
 
-void hinoko_fw_iso_resource_once_deallocate_async(HinokoFwIsoResourceOnce *self, guint channel,
-						  guint bandwidth, GError **error);
+gboolean hinoko_fw_iso_resource_once_deallocate_async(HinokoFwIsoResourceOnce *self, guint channel,
+						      guint bandwidth, GError **error);
 
-void hinoko_fw_iso_resource_once_allocate_sync(HinokoFwIsoResourceOnce *self,
-					       guint8 *channel_candidates,
-					       gsize channel_candidates_count,
-					       guint bandwidth, guint timeout_ms,
-					       GError **error);
+gboolean hinoko_fw_iso_resource_once_allocate_sync(HinokoFwIsoResourceOnce *self,
+						   guint8 *channel_candidates,
+					           gsize channel_candidates_count,
+					           guint bandwidth, guint timeout_ms,
+					           GError **error);
 
-void hinoko_fw_iso_resource_once_deallocate_sync(HinokoFwIsoResourceOnce *self, guint channel,
-						 guint bandwidth, guint timeout_ms,
-						 GError **error);
+gboolean hinoko_fw_iso_resource_once_deallocate_sync(HinokoFwIsoResourceOnce *self, guint channel,
+						     guint bandwidth, guint timeout_ms,
+						     GError **error);
 
 G_END_DECLS
 

--- a/src/fw_iso_resource_private.c
+++ b/src/fw_iso_resource_private.c
@@ -58,7 +58,7 @@ void fw_iso_resource_state_init(struct fw_iso_resource_state *state)
 
 void fw_iso_resource_state_release(struct fw_iso_resource_state *state)
 {
-	if (state->fd < 0)
+	if (state->fd >= 0)
 		close(state->fd);
 	state->fd = -1;
 }

--- a/src/fw_iso_resource_private.h
+++ b/src/fw_iso_resource_private.h
@@ -69,8 +69,8 @@ struct fw_iso_resource_waiter {
 void fw_iso_resource_waiter_init(struct fw_iso_resource_waiter *w, HinokoFwIsoResource *self,
 				 const char *signal_name, guint timeout_ms);
 
-void fw_iso_resource_waiter_wait(struct fw_iso_resource_waiter *w, HinokoFwIsoResource *self,
-				 GError **error);
+gboolean fw_iso_resource_waiter_wait(struct fw_iso_resource_waiter *w, HinokoFwIsoResource *self,
+				     GError **error);
 
 void parse_iso_resource_event(const struct fw_cdev_event_iso_resource *ev, guint *channel,
 			      guint *bandwidth, const char **signal_name, GError **error);

--- a/src/fw_iso_rx_multiple.h
+++ b/src/fw_iso_rx_multiple.h
@@ -26,25 +26,19 @@ struct _HinokoFwIsoRxMultipleClass {
 
 HinokoFwIsoRxMultiple *hinoko_fw_iso_rx_multiple_new(void);
 
-void hinoko_fw_iso_rx_multiple_allocate(HinokoFwIsoRxMultiple *self,
-					const char *path,
-					const guint8 *channels,
-					guint channels_length,
-					GError **error);
+gboolean hinoko_fw_iso_rx_multiple_allocate(HinokoFwIsoRxMultiple *self, const char *path,
+					    const guint8 *channels, guint channels_length,
+					    GError **error);
 
-void hinoko_fw_iso_rx_multiple_map_buffer(HinokoFwIsoRxMultiple *self,
-					  guint bytes_per_chunk,
-					  guint chunks_per_buffer,
-					  GError **error);
+gboolean hinoko_fw_iso_rx_multiple_map_buffer(HinokoFwIsoRxMultiple *self, guint bytes_per_chunk,
+					      guint chunks_per_buffer, GError **error);
 
-void hinoko_fw_iso_rx_multiple_start(HinokoFwIsoRxMultiple *self,
-				     const guint16 *cycle_match, guint32 sync,
-				     HinokoFwIsoCtxMatchFlag tags,
-				     guint chunks_per_irq, GError **error);
+gboolean hinoko_fw_iso_rx_multiple_start(HinokoFwIsoRxMultiple *self, const guint16 *cycle_match,
+					 guint32 sync, HinokoFwIsoCtxMatchFlag tags,
+					 guint chunks_per_irq, GError **error);
 
-void hinoko_fw_iso_rx_multiple_get_payload(HinokoFwIsoRxMultiple *self,
-					guint index, const guint8 **payload,
-					guint *length, GError **error);
+void hinoko_fw_iso_rx_multiple_get_payload(HinokoFwIsoRxMultiple *self, guint index,
+					   const guint8 **payload, guint *length);
 
 G_END_DECLS
 

--- a/src/fw_iso_rx_single.c
+++ b/src/fw_iso_rx_single.c
@@ -246,24 +246,28 @@ HinokoFwIsoRxSingle *hinoko_fw_iso_rx_single_new(void)
  * Allocate an IR context to 1394 OHCI controller for packet-per-buffer mode. A local node of the
  * node corresponding to the given path is used as the controller, thus any path is accepted as
  * long as process has enough permission for the path.
+ *
+ * Returns: TRUE if the overall operation finishes successfully, else FALSE.
+ *
+ * Since: 0.7.
  */
-void hinoko_fw_iso_rx_single_allocate(HinokoFwIsoRxSingle *self,
-				      const char *path,
-				      guint channel, guint header_size,
-				      GError **error)
+gboolean hinoko_fw_iso_rx_single_allocate(HinokoFwIsoRxSingle *self, const char *path,
+					  guint channel, guint header_size, GError **error)
 {
 	HinokoFwIsoRxSinglePrivate *priv;
 
-	g_return_if_fail(HINOKO_IS_FW_ISO_RX_SINGLE(self));
-	g_return_if_fail(error == NULL || *error == NULL);
+	g_return_val_if_fail(HINOKO_IS_FW_ISO_RX_SINGLE(self), FALSE);
+	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
 
 	priv = hinoko_fw_iso_rx_single_get_instance_private(self);
 
 	if (!fw_iso_ctx_state_allocate(&priv->state, path, HINOKO_FW_ISO_CTX_MODE_RX_SINGLE, 0,
 				       channel, header_size, error))
-		return;
+		return FALSE;
 
 	priv->header_size = header_size;
+
+	return TRUE;
 }
 
 /*
@@ -274,21 +278,24 @@ void hinoko_fw_iso_rx_single_allocate(HinokoFwIsoRxSingle *self,
  * @error: A [struct@GLib.Error].
  *
  * Map intermediate buffer to share payload of IR context with 1394 OHCI controller.
+ *
+ * Returns: TRUE if the overall operation finishes successfully, else FALSE.
+ *
+ * Since: 0.7.
  */
-void hinoko_fw_iso_rx_single_map_buffer(HinokoFwIsoRxSingle *self,
-					guint maximum_bytes_per_payload,
-					guint payloads_per_buffer,
-					GError **error)
+gboolean hinoko_fw_iso_rx_single_map_buffer(HinokoFwIsoRxSingle *self,
+					    guint maximum_bytes_per_payload,
+					    guint payloads_per_buffer, GError **error)
 {
 	HinokoFwIsoRxSinglePrivate *priv;
 
-	g_return_if_fail(HINOKO_IS_FW_ISO_RX_SINGLE(self));
-	g_return_if_fail(error == NULL || *error == NULL);
+	g_return_val_if_fail(HINOKO_IS_FW_ISO_RX_SINGLE(self), FALSE);
+	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
 
 	priv = hinoko_fw_iso_rx_single_get_instance_private(self);
 
-	(void)fw_iso_ctx_state_map_buffer(&priv->state, maximum_bytes_per_payload,
-					  payloads_per_buffer, error);
+	return fw_iso_ctx_state_map_buffer(&priv->state, maximum_bytes_per_payload,
+					   payloads_per_buffer, error);
 }
 
 /**
@@ -301,18 +308,20 @@ void hinoko_fw_iso_rx_single_map_buffer(HinokoFwIsoRxSingle *self,
  * hardware interrupt to generate interrupt event. In detail, please refer to documentation about
  * [signal@FwIsoRxSingle::interrupted] signal.
  *
- * Since: 0.6.
+ * Returns: TRUE if the overall operation finishes successfully, else FALSE.
+ *
+ * Since: 0.7.
  */
-void hinoko_fw_iso_rx_single_register_packet(HinokoFwIsoRxSingle *self, gboolean schedule_interrupt,
-					     GError **error)
+gboolean hinoko_fw_iso_rx_single_register_packet(HinokoFwIsoRxSingle *self,
+						 gboolean schedule_interrupt, GError **error)
 {
 	HinokoFwIsoRxSinglePrivate *priv;
 
-	g_return_if_fail(HINOKO_IS_FW_ISO_RX_SINGLE(self));
+	g_return_val_if_fail(HINOKO_IS_FW_ISO_RX_SINGLE(self), FALSE);
 	priv = hinoko_fw_iso_rx_single_get_instance_private(self);
 
-	(void)fw_iso_ctx_state_register_chunk(&priv->state, FALSE, 0, 0, NULL, 0, 0,
-					      schedule_interrupt, error);
+	return fw_iso_ctx_state_register_chunk(&priv->state, FALSE, 0, 0, NULL, 0, 0,
+					       schedule_interrupt, error);
 }
 
 /**
@@ -328,37 +337,40 @@ void hinoko_fw_iso_rx_single_register_packet(HinokoFwIsoRxSingle *self, gboolean
  *
  * Start IR context.
  *
- * Since: 0.6.
+ * Returns: TRUE if the overall operation finishes successfully, else FALSE.
+ *
+ * Since: 0.7.
  */
-void hinoko_fw_iso_rx_single_start(HinokoFwIsoRxSingle *self, const guint16 *cycle_match,
-				   guint32 sync, HinokoFwIsoCtxMatchFlag tags, GError **error)
+gboolean hinoko_fw_iso_rx_single_start(HinokoFwIsoRxSingle *self, const guint16 *cycle_match,
+				       guint32 sync, HinokoFwIsoCtxMatchFlag tags, GError **error)
 {
 	HinokoFwIsoRxSinglePrivate *priv;
 
-	g_return_if_fail(HINOKO_IS_FW_ISO_RX_SINGLE(self));
-	g_return_if_fail(error == NULL || *error == NULL);
+	g_return_val_if_fail(HINOKO_IS_FW_ISO_RX_SINGLE(self), FALSE);
+	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
 
 	priv = hinoko_fw_iso_rx_single_get_instance_private(self);
 
 	priv->chunk_cursor = 0;
 
-	(void)fw_iso_ctx_state_start(&priv->state, cycle_match, sync, tags, error);
+	return fw_iso_ctx_state_start(&priv->state, cycle_match, sync, tags, error);
 }
 
 /**
  * hinoko_fw_iso_rx_single_get_payload:
  * @self: A [class@FwIsoRxSingle].
- * @index: the index inner available packets.
+ * @index: the index inner available packets at the event of interrupt.
  * @payload: (element-type guint8)(array length=length)(out)(transfer none): The array with data
  *	     frame for payload of IR context.
  * @length: The number of bytes in the above payload.
- * @error: A [struct@GLib.Error].
  *
- * Retrieve payload of IR context for a handled packet corresponding to index.
+ * Retrieve payload of IR context for a handled packet corresponding to index at the event of
+ * interrupt.
+ *
+ * Since: 0.7.
  */
 void hinoko_fw_iso_rx_single_get_payload(HinokoFwIsoRxSingle *self, guint index,
-					 const guint8 **payload, guint *length,
-					 GError **error)
+					 const guint8 **payload, guint *length)
 {
 	HinokoFwIsoRxSinglePrivate *priv;
 	unsigned int bytes_per_chunk;
@@ -369,7 +381,6 @@ void hinoko_fw_iso_rx_single_get_payload(HinokoFwIsoRxSingle *self, guint index,
 	guint frame_size;
 
 	g_return_if_fail(HINOKO_IS_FW_ISO_RX_SINGLE(self));
-	g_return_if_fail(error == NULL || *error == NULL);
 
 	priv = hinoko_fw_iso_rx_single_get_instance_private(self);
 

--- a/src/fw_iso_rx_single.h
+++ b/src/fw_iso_rx_single.h
@@ -33,25 +33,21 @@ struct _HinokoFwIsoRxSingleClass {
 
 HinokoFwIsoRxSingle *hinoko_fw_iso_rx_single_new(void);
 
-void hinoko_fw_iso_rx_single_allocate(HinokoFwIsoRxSingle *self,
-				      const char *path,
-				      guint channel, guint header_size,
-				      GError **error);
+gboolean hinoko_fw_iso_rx_single_allocate(HinokoFwIsoRxSingle *self, const char *path,
+					  guint channel, guint header_size, GError **error);
 
-void hinoko_fw_iso_rx_single_map_buffer(HinokoFwIsoRxSingle *self,
-					guint maximum_bytes_per_payload,
-					guint payloads_per_buffer,
-					GError **error);
+gboolean hinoko_fw_iso_rx_single_map_buffer(HinokoFwIsoRxSingle *self,
+					    guint maximum_bytes_per_payload,
+					    guint payloads_per_buffer, GError **error);
 
-void hinoko_fw_iso_rx_single_register_packet(HinokoFwIsoRxSingle *self, gboolean schedule_interrupt,
-					     GError **error);
+gboolean hinoko_fw_iso_rx_single_register_packet(HinokoFwIsoRxSingle *self,
+						 gboolean schedule_interrupt, GError **error);
 
-void hinoko_fw_iso_rx_single_start(HinokoFwIsoRxSingle *self, const guint16 *cycle_match,
-				   guint32 sync, HinokoFwIsoCtxMatchFlag tags, GError **error);
+gboolean hinoko_fw_iso_rx_single_start(HinokoFwIsoRxSingle *self, const guint16 *cycle_match,
+				       guint32 sync, HinokoFwIsoCtxMatchFlag tags, GError **error);
 
 void hinoko_fw_iso_rx_single_get_payload(HinokoFwIsoRxSingle *self, guint index,
-					 const guint8 **payload, guint *length,
-					 GError **error);
+					 const guint8 **payload, guint *length);
 
 G_END_DECLS
 

--- a/src/fw_iso_tx.c
+++ b/src/fw_iso_tx.c
@@ -232,19 +232,22 @@ HinokoFwIsoTx *hinoko_fw_iso_tx_new(void)
  * Allocate an IT context to 1394 OHCI controller. A local node of the node corresponding to the
  * given path is used as the controller, thus any path is accepted as long as process has enough
  * permission for the path.
+ *
+ * Returns: TRUE if the overall operation finishes successful, else FALSE.
+ *
+ * Since: 0.7.
  */
-void hinoko_fw_iso_tx_allocate(HinokoFwIsoTx *self, const char *path,
-			       HinokoFwScode scode, guint channel,
-			       guint header_size, GError **error)
+gboolean hinoko_fw_iso_tx_allocate(HinokoFwIsoTx *self, const char *path, HinokoFwScode scode,
+				   guint channel, guint header_size, GError **error)
 {
 	HinokoFwIsoTxPrivate *priv;
 
-	g_return_if_fail(HINOKO_IS_FW_ISO_TX(self));
-	g_return_if_fail(error == NULL || *error == NULL);
+	g_return_val_if_fail(HINOKO_IS_FW_ISO_TX(self), FALSE);
+	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
 	priv = hinoko_fw_iso_tx_get_instance_private(self);
 
-	(void)fw_iso_ctx_state_allocate(&priv->state, path, HINOKO_FW_ISO_CTX_MODE_TX, scode,
-					channel, header_size, error);
+	return fw_iso_ctx_state_allocate(&priv->state, path, HINOKO_FW_ISO_CTX_MODE_TX, scode,
+					 channel, header_size, error);
 }
 
 /**
@@ -255,20 +258,22 @@ void hinoko_fw_iso_tx_allocate(HinokoFwIsoTx *self, const char *path,
  * @error: A [struct@GLib.Error].
  *
  * Map intermediate buffer to share payload of IT context with 1394 OHCI controller.
+ *
+ * Returns: TRUE if the overall operation finishes successful, else FALSE.
+ *
+ * Since: 0.7.
  */
-void hinoko_fw_iso_tx_map_buffer(HinokoFwIsoTx *self,
-				 guint maximum_bytes_per_payload,
-				 guint payloads_per_buffer,
-				 GError **error)
+gboolean hinoko_fw_iso_tx_map_buffer(HinokoFwIsoTx *self, guint maximum_bytes_per_payload,
+				     guint payloads_per_buffer, GError **error)
 {
 	HinokoFwIsoTxPrivate *priv;
 
-	g_return_if_fail(HINOKO_IS_FW_ISO_TX(self));
-	g_return_if_fail(error == NULL || *error == NULL);
+	g_return_val_if_fail(HINOKO_IS_FW_ISO_TX(self), FALSE);
+	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
 	priv = hinoko_fw_iso_tx_get_instance_private(self);
 
-	(void)fw_iso_ctx_state_map_buffer(&priv->state, maximum_bytes_per_payload,
-					  payloads_per_buffer, error);
+	return fw_iso_ctx_state_map_buffer(&priv->state, maximum_bytes_per_payload,
+					   payloads_per_buffer, error);
 }
 
 /**
@@ -282,17 +287,19 @@ void hinoko_fw_iso_tx_map_buffer(HinokoFwIsoTx *self,
  *
  * Start IT context.
  *
- * Since: 0.6.
+ * Returns: TRUE if the overall operation finishes successful, else FALSE.
+ *
+ * Since: 0.7.
  */
-void hinoko_fw_iso_tx_start(HinokoFwIsoTx *self, const guint16 *cycle_match, GError **error)
+gboolean hinoko_fw_iso_tx_start(HinokoFwIsoTx *self, const guint16 *cycle_match, GError **error)
 {
 	HinokoFwIsoTxPrivate *priv;
 
-	g_return_if_fail(HINOKO_IS_FW_ISO_TX(self));
-	g_return_if_fail(error == NULL || *error == NULL);
+	g_return_val_if_fail(HINOKO_IS_FW_ISO_TX(self), FALSE);
+	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
 	priv = hinoko_fw_iso_tx_get_instance_private(self);
 
-	(void)fw_iso_ctx_state_start(&priv->state, cycle_match, 0, 0, error);
+	return fw_iso_ctx_state_start(&priv->state, cycle_match, 0, 0, error);
 }
 
 /**
@@ -312,25 +319,27 @@ void hinoko_fw_iso_tx_start(HinokoFwIsoTx *self, const guint16 *cycle_match, GEr
  * interrupt to generate interrupt event. In detail, please refer to documentation about
  * [signal@FwIsoTx::interrupted].
  *
- * Since: 0.6.
+ * Returns: TRUE if the overall operation finishes successful, else FALSE.
+ *
+ * Since: 0.7.
  */
-void hinoko_fw_iso_tx_register_packet(HinokoFwIsoTx *self,
-				HinokoFwIsoCtxMatchFlag tags, guint sy,
-				const guint8 *header, guint header_length,
-				const guint8 *payload, guint payload_length,
-				gboolean schedule_interrupt, GError **error)
+gboolean hinoko_fw_iso_tx_register_packet(HinokoFwIsoTx *self, HinokoFwIsoCtxMatchFlag tags,
+					  guint sy,
+					  const guint8 *header, guint header_length,
+					  const guint8 *payload, guint payload_length,
+					  gboolean schedule_interrupt, GError **error)
 {
 	HinokoFwIsoTxPrivate *priv;
 	const guint8 *frames;
 	guint frame_size;
 	gboolean skip;
 
-	g_return_if_fail(HINOKO_IS_FW_ISO_TX(self));
-	g_return_if_fail((header != NULL && header_length > 0) ||
-			 (header == NULL && header_length == 0));
-	g_return_if_fail((payload != NULL && payload_length > 0) ||
-			 (payload == NULL && payload_length == 0));
-	g_return_if_fail(error == NULL || *error == NULL);
+	g_return_val_if_fail(HINOKO_IS_FW_ISO_TX(self), FALSE);
+	g_return_val_if_fail((header != NULL && header_length > 0) ||
+			     (header == NULL && header_length == 0), FALSE);
+	g_return_val_if_fail((payload != NULL && payload_length > 0) ||
+			     (payload == NULL && payload_length == 0), FALSE);
+	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
 
 	priv = hinoko_fw_iso_tx_get_instance_private(self);
 
@@ -340,7 +349,7 @@ void hinoko_fw_iso_tx_register_packet(HinokoFwIsoTx *self,
 
 	if (!fw_iso_ctx_state_register_chunk(&priv->state, skip, tags, sy, header, header_length,
 					     payload_length, schedule_interrupt, error))
-		return;
+		return FALSE;
 
 	fw_iso_ctx_state_read_frame(&priv->state, priv->offset, payload_length, &frames,
 				    &frame_size);
@@ -356,4 +365,6 @@ void hinoko_fw_iso_tx_register_packet(HinokoFwIsoTx *self,
 
 		priv->offset = frame_size;
 	}
+
+	return TRUE;
 }

--- a/src/fw_iso_tx.c
+++ b/src/fw_iso_tx.c
@@ -163,6 +163,9 @@ gboolean fw_iso_tx_handle_event(HinokoFwIsoCtx *inst, const union fw_cdev_event 
 	HinokoFwIsoTxPrivate *priv;
 
 	const struct fw_cdev_event_iso_interrupt *ev;
+	guint sec;
+	guint cycle;
+	unsigned int pkt_count;
 
 	g_return_val_if_fail(HINOKO_FW_ISO_TX(inst), FALSE);
 	g_return_val_if_fail(event->common.type == FW_CDEV_EVENT_ISO_INTERRUPT, FALSE);
@@ -172,9 +175,9 @@ gboolean fw_iso_tx_handle_event(HinokoFwIsoCtx *inst, const union fw_cdev_event 
 
 	ev = &event->iso_interrupt;
 
-	guint sec = (ev->cycle & 0x0000e000) >> 13;
-	guint cycle = ev->cycle & 0x00001fff;
-	unsigned int pkt_count = ev->header_length / 4;
+	sec = (ev->cycle & 0x0000e000) >> 13;
+	cycle = ev->cycle & 0x00001fff;
+	pkt_count = ev->header_length / 4;
 
 	g_signal_emit(inst, fw_iso_tx_sigs[FW_ISO_TX_SIG_TYPE_IRQ], 0, sec, cycle, ev->header,
 		      ev->header_length, pkt_count);

--- a/src/fw_iso_tx.h
+++ b/src/fw_iso_tx.h
@@ -32,22 +32,19 @@ struct _HinokoFwIsoTxClass {
 
 HinokoFwIsoTx *hinoko_fw_iso_tx_new(void);
 
-void hinoko_fw_iso_tx_allocate(HinokoFwIsoTx *self, const char *path,
-			       HinokoFwScode scode, guint channel,
-			       guint header_size, GError **error);
+gboolean hinoko_fw_iso_tx_allocate(HinokoFwIsoTx *self, const char *path, HinokoFwScode scode,
+				   guint channel, guint header_size, GError **error);
 
-void hinoko_fw_iso_tx_map_buffer(HinokoFwIsoTx *self,
-				 guint maximum_bytes_per_payload,
-				 guint payloads_per_buffer,
-				 GError **error);
+gboolean hinoko_fw_iso_tx_map_buffer(HinokoFwIsoTx *self, guint maximum_bytes_per_payload,
+				     guint payloads_per_buffer, GError **error);
 
-void hinoko_fw_iso_tx_start(HinokoFwIsoTx *self, const guint16 *cycle_match, GError **error);
+gboolean hinoko_fw_iso_tx_start(HinokoFwIsoTx *self, const guint16 *cycle_match, GError **error);
 
-void hinoko_fw_iso_tx_register_packet(HinokoFwIsoTx *self,
-				HinokoFwIsoCtxMatchFlag tags, guint sy,
-				const guint8 *header, guint header_length,
-				const guint8 *payload, guint payload_length,
-				gboolean schedule_interrupt, GError **error);
+gboolean hinoko_fw_iso_tx_register_packet(HinokoFwIsoTx *self, HinokoFwIsoCtxMatchFlag tags,
+					  guint sy,
+					  const guint8 *header, guint header_length,
+					  const guint8 *payload, guint payload_length,
+					  gboolean schedule_interrupt, GError **error);
 
 G_END_DECLS
 

--- a/src/hinoko.map
+++ b/src/hinoko.map
@@ -7,10 +7,6 @@ HINOKO_0_1_0 {
     "hinoko_fw_iso_rx_single_new";
 
     "hinoko_fw_iso_rx_multiple_new";
-    "hinoko_fw_iso_rx_multiple_allocate";
-    "hinoko_fw_iso_rx_multiple_map_buffer";
-    "hinoko_fw_iso_rx_multiple_start";
-    "hinoko_fw_iso_rx_multiple_get_payload";
 
     "hinoko_fw_iso_tx_new";
     "hinoko_fw_iso_tx_allocate";
@@ -73,6 +69,11 @@ HINOKO_0_7_0 {
     "hinoko_fw_iso_rx_single_get_payload";
 
     "hinoko_fw_iso_rx_multiple_get_type";
+    "hinoko_fw_iso_rx_multiple_allocate";
+    "hinoko_fw_iso_rx_multiple_map_buffer";
+    "hinoko_fw_iso_rx_multiple_start";
+    "hinoko_fw_iso_rx_multiple_get_payload";
+
     "hinoko_fw_iso_tx_get_type";
 
     "hinoko_fw_iso_resource_get_type";

--- a/src/hinoko.map
+++ b/src/hinoko.map
@@ -5,9 +5,6 @@ HINOKO_0_1_0 {
     "hinoko_fw_iso_ctx_match_flag_get_type";
 
     "hinoko_fw_iso_rx_single_new";
-    "hinoko_fw_iso_rx_single_allocate";
-    "hinoko_fw_iso_rx_single_map_buffer";
-    "hinoko_fw_iso_rx_single_get_payload";
 
     "hinoko_fw_iso_rx_multiple_new";
     "hinoko_fw_iso_rx_multiple_allocate";
@@ -56,9 +53,6 @@ HINOKO_0_6_0 {
   global:
     "hinoko_fw_iso_tx_register_packet";
     "hinoko_fw_iso_tx_start";
-
-    "hinoko_fw_iso_rx_single_register_packet";
-    "hinoko_fw_iso_rx_single_start";
 } HINOKO_0_5_0;
 
 HINOKO_0_7_0 {
@@ -72,6 +66,12 @@ HINOKO_0_7_0 {
     "hinoko_fw_iso_ctx_flush_completions";
 
     "hinoko_fw_iso_rx_single_get_type";
+    "hinoko_fw_iso_rx_single_allocate";
+    "hinoko_fw_iso_rx_single_map_buffer";
+    "hinoko_fw_iso_rx_single_register_packet";
+    "hinoko_fw_iso_rx_single_start";
+    "hinoko_fw_iso_rx_single_get_payload";
+
     "hinoko_fw_iso_rx_multiple_get_type";
     "hinoko_fw_iso_tx_get_type";
 

--- a/src/hinoko.map
+++ b/src/hinoko.map
@@ -4,9 +4,6 @@ HINOKO_0_1_0 {
     "hinoko_fw_scode_get_type";
     "hinoko_fw_iso_ctx_match_flag_get_type";
 
-    "hinoko_fw_iso_ctx_get_cycle_timer";
-    "hinoko_fw_iso_ctx_create_source";
-
     "hinoko_fw_iso_rx_single_new";
     "hinoko_fw_iso_rx_single_allocate";
     "hinoko_fw_iso_rx_single_map_buffer";
@@ -57,8 +54,6 @@ HINOKO_0_5_0 {
 
 HINOKO_0_6_0 {
   global:
-    "hinoko_fw_iso_ctx_flush_completions";
-
     "hinoko_fw_iso_tx_register_packet";
     "hinoko_fw_iso_tx_start";
 
@@ -72,6 +67,9 @@ HINOKO_0_7_0 {
     "hinoko_fw_iso_ctx_stop";
     "hinoko_fw_iso_ctx_unmap_buffer";
     "hinoko_fw_iso_ctx_release";
+    "hinoko_fw_iso_ctx_get_cycle_timer";
+    "hinoko_fw_iso_ctx_create_source";
+    "hinoko_fw_iso_ctx_flush_completions";
 
     "hinoko_fw_iso_rx_single_get_type";
     "hinoko_fw_iso_rx_multiple_get_type";

--- a/src/hinoko.map
+++ b/src/hinoko.map
@@ -9,8 +9,6 @@ HINOKO_0_1_0 {
     "hinoko_fw_iso_rx_multiple_new";
 
     "hinoko_fw_iso_tx_new";
-    "hinoko_fw_iso_tx_allocate";
-    "hinoko_fw_iso_tx_map_buffer";
   local:
     *;
 };
@@ -45,12 +43,6 @@ HINOKO_0_5_0 {
     "hinoko_fw_iso_ctx_error_quark";
 } HINOKO_0_4_0;
 
-HINOKO_0_6_0 {
-  global:
-    "hinoko_fw_iso_tx_register_packet";
-    "hinoko_fw_iso_tx_start";
-} HINOKO_0_5_0;
-
 HINOKO_0_7_0 {
   global:
     "hinoko_fw_iso_ctx_get_type";
@@ -75,6 +67,10 @@ HINOKO_0_7_0 {
     "hinoko_fw_iso_rx_multiple_get_payload";
 
     "hinoko_fw_iso_tx_get_type";
+    "hinoko_fw_iso_tx_allocate";
+    "hinoko_fw_iso_tx_map_buffer";
+    "hinoko_fw_iso_tx_register_packet";
+    "hinoko_fw_iso_tx_start";
 
     "hinoko_fw_iso_resource_get_type";
     "hinoko_fw_iso_resource_open";

--- a/src/hinoko.map
+++ b/src/hinoko.map
@@ -27,8 +27,6 @@ HINOKO_0_4_0 {
     "hinoko_fw_iso_resource_calculate_bandwidth";
 
     "hinoko_fw_iso_resource_auto_new";
-    "hinoko_fw_iso_resource_auto_allocate_async";
-    "hinoko_fw_iso_resource_auto_deallocate_async";
 } HINOKO_0_3_0;
 
 HINOKO_0_5_0 {
@@ -77,6 +75,8 @@ HINOKO_0_7_0 {
     "hinoko_fw_iso_resource_create_source";
 
     "hinoko_fw_iso_resource_auto_get_type";
+    "hinoko_fw_iso_resource_auto_allocate_async";
+    "hinoko_fw_iso_resource_auto_deallocate_async";
     "hinoko_fw_iso_resource_auto_allocate_sync";
     "hinoko_fw_iso_resource_auto_deallocate_sync";
 


### PR DESCRIPTION
This patchset is take 2 for #14 which is once merged but reverted. As a result, most of public API
returns gboolean to express whether the overall operation finishes successfully or not. Via GObject
Introspection, it brings an additional return value for each call.

```
Takashi Sakamoto (10):
  fw_iso_resource_private: fix inverted condition to close file descriptor
  fw_iso_tx: fix the position of declaration for automatic variables
  fw_iso_ctx: rewrite public API to return gboolean
  fw_iso_rx_single: rewrite public API to return gboolean according to GNOME convention
  fw_iso_rx_multiple: rewrite public API to return gboolean according to GNOME convention
  fw_iso_tx: rewrite public API to return gboolean according to GNOME convention
  fw_iso_resource: rewrite public API to return gboolean according to GNOME convention
  fw_iso_resource_auto: rewrite public API to return gboolean according to GNOME convention
  fw_iso_resource_once: rewrite public API to return gboolean according to GNOME convention
  update README

 README.rst                    |  4 ++
 samples/iso-resource          |  4 +-
 samples/iso-rx-multiple       |  2 +-
 samples/iso-rx-single         |  4 +-
 samples/iso-tx                |  4 +-
 src/fw_iso_ctx.c              | 43 +++++++++------
 src/fw_iso_ctx.h              |  9 ++--
 src/fw_iso_ctx_private.c      |  6 +++
 src/fw_iso_resource.c         | 28 +++++-----
 src/fw_iso_resource.h         |  8 +--
 src/fw_iso_resource_auto.c    | 99 ++++++++++++++++++++++-------------
 src/fw_iso_resource_auto.h    | 34 ++++++------
 src/fw_iso_resource_once.c    | 88 ++++++++++++++++++-------------
 src/fw_iso_resource_once.h    | 34 ++++++------
 src/fw_iso_resource_private.c | 21 +++++---
 src/fw_iso_resource_private.h |  4 +-
 src/fw_iso_rx_multiple.c      | 64 +++++++++++-----------
 src/fw_iso_rx_multiple.h      | 32 +++++------
 src/fw_iso_rx_single.c        | 77 +++++++++++++++------------
 src/fw_iso_rx_single.h        | 24 ++++-----
 src/fw_iso_tx.c               | 86 +++++++++++++++++-------------
 src/fw_iso_tx.h               | 29 +++++-----
 src/hinoko.map                | 45 +++++++---------
 23 files changed, 413 insertions(+), 336 deletions(-)
```