### PR TITLE
[PATCH 0/4] fw_iso_resource: add interface and implementation for resourec allocation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@
 libhinoko
 =========
 
-2022/05/05
+2022/05/07
 Takashi Sakamoto
 
 Introduction
@@ -98,8 +98,6 @@ The latter is implemented by below classes inherits GObject directly:
 The ``Hinoko.FwIsoResourceOnce`` is newly added for allocation of isochronous resource bound
 to current generation of bus topology, and some functions are available:
 
-- ``Hinoko.FwIsoResourceOnce.allocate_async``
-- ``Hinoko.FwIsoResourceOnce.allocate_sync``
 - ``Hinoko.FwIsoResourceOnce.deallocate_async``
 - ``Hinoko.FwIsoResourceOnce.deallocate_sync``
 
@@ -121,17 +119,20 @@ Below functions are removed as well:
 - ``Hinoko.FwIsoTx.stop``
 - ``Hinoko.FwIsoTx.unmap_buffer``
 - ``Hinoko.FwIsoTx.release``
+- ``Hinoko.FwIsoResourceAuto.allocate_async``
+- ``Hinoko.FwIsoResourceAuto.allocate_sync``
 
 Alternatively, below functions are available:
 
 - ``Hinoko.FwIsoCtx.stop``
 - ``Hinoko.FwIsoCtx.unmap_buffer``
 - ``Hinoko.FwIsoCtx.release``
+- ``Hinoko.FwIsoResource.allocate_async``
+- ``Hinoko.FwIsoResource.allocate_sync``
 
 Furthermore, below puclic functions are changed to have an argument for the value of timeout to
 wait for event:
 
-- ``Hinoko.FwIsoResourceAuto.allocate_sync``
 - ``Hinoko.FwIsoResourceAuto.deallocate_sync``
 
 Beside, below signal is newly added to express the value of current generation for the state of

--- a/src/fw_iso_resource.h
+++ b/src/fw_iso_resource.h
@@ -20,6 +20,10 @@ struct _HinokoFwIsoResourceInterface {
 	gboolean (*open)(HinokoFwIsoResource *self, const gchar *path, gint open_flag,
 			 GError **error);
 
+	gboolean (*allocate_async)(HinokoFwIsoResource *self,
+				   guint8 *channel_candidates, gsize channel_candidates_count,
+				   guint bandwidth, GError **error);
+
 	gboolean (*create_source)(HinokoFwIsoResource *self, GSource **source, GError **error);
 
 	/**
@@ -58,6 +62,16 @@ gboolean hinoko_fw_iso_resource_open(HinokoFwIsoResource *self, const gchar *pat
 
 gboolean hinoko_fw_iso_resource_create_source(HinokoFwIsoResource *self, GSource **source,
 					      GError **error);
+
+gboolean hinoko_fw_iso_resource_allocate_async(HinokoFwIsoResource *self,
+					       guint8 *channel_candidates,
+					       gsize channel_candidates_count,
+					       guint bandwidth, GError **error);
+
+gboolean hinoko_fw_iso_resource_allocate_sync(HinokoFwIsoResource *self,
+					      guint8 *channel_candidates,
+				              gsize channel_candidates_count,
+				              guint bandwidth, guint timeout_ms, GError **error);
 
 guint hinoko_fw_iso_resource_calculate_bandwidth(guint bytes_per_payload,
 						 HinokoFwScode scode);

--- a/src/fw_iso_resource_auto.c
+++ b/src/fw_iso_resource_auto.c
@@ -140,6 +140,58 @@ static gboolean fw_iso_resource_auto_open(HinokoFwIsoResource *inst, const gchar
 	return fw_iso_resource_state_open(&priv->state, path, open_flag, error);
 }
 
+static gboolean fw_iso_resource_auto_allocate_async(HinokoFwIsoResource *inst,
+						    guint8 *channel_candidates,
+						    gsize channel_candidates_count,
+						    guint bandwidth,
+						    GError **error)
+{
+	HinokoFwIsoResourceAuto *self;
+	HinokoFwIsoResourceAutoPrivate *priv;
+	struct fw_cdev_allocate_iso_resource res = {0};
+	gboolean result;
+	int i;
+
+	g_return_val_if_fail(HINOKO_IS_FW_ISO_RESOURCE_AUTO(inst), FALSE);
+	g_return_val_if_fail(channel_candidates != NULL, FALSE);
+	g_return_val_if_fail(channel_candidates_count > 0, FALSE);
+	g_return_val_if_fail(bandwidth > 0, FALSE);
+	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
+
+	self = HINOKO_FW_ISO_RESOURCE_AUTO(inst);
+	priv = hinoko_fw_iso_resource_auto_get_instance_private(self);
+	if (priv->state.fd < 0) {
+		generate_coded_error(error, HINOKO_FW_ISO_RESOURCE_ERROR_NOT_OPENED);
+		return FALSE;
+	}
+
+	g_mutex_lock(&priv->mutex);
+
+	if (priv->is_allocated) {
+		generate_local_error(error, HINOKO_FW_ISO_RESOURCE_AUTO_ERROR_ALLOCATED);
+		result = FALSE;
+		goto end;
+	}
+
+	for (i = 0; i < channel_candidates_count; ++i) {
+		if (channel_candidates[i] < 64)
+			res.channels |= 1ull << channel_candidates[i];
+	}
+	res.bandwidth = bandwidth;
+
+	if (ioctl(priv->state.fd, FW_CDEV_IOC_ALLOCATE_ISO_RESOURCE, &res) < 0) {
+		generate_ioctl_error(error, errno, FW_CDEV_IOC_ALLOCATE_ISO_RESOURCE);
+		result = FALSE;
+	} else {
+		priv->handle = res.handle;
+		result = TRUE;
+	}
+end:
+	g_mutex_unlock(&priv->mutex);
+
+	return result;
+}
+
 static void handle_iso_resource_event(HinokoFwIsoResourceAuto *self,
 				      const struct fw_cdev_event_iso_resource *ev)
 {
@@ -279,48 +331,9 @@ gboolean hinoko_fw_iso_resource_auto_allocate_async(HinokoFwIsoResourceAuto *sel
 						    guint bandwidth,
 						    GError **error)
 {
-	HinokoFwIsoResourceAutoPrivate *priv;
-	struct fw_cdev_allocate_iso_resource res = {0};
-	gboolean result;
-	int i;
-
-	g_return_val_if_fail(HINOKO_IS_FW_ISO_RESOURCE_AUTO(self), FALSE);
-	g_return_val_if_fail(channel_candidates != NULL, FALSE);
-	g_return_val_if_fail(channel_candidates_count > 0, FALSE);
-	g_return_val_if_fail(bandwidth > 0, FALSE);
-	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
-
-	priv = hinoko_fw_iso_resource_auto_get_instance_private(self);
-	if (priv->state.fd < 0) {
-		generate_coded_error(error, HINOKO_FW_ISO_RESOURCE_ERROR_NOT_OPENED);
-		return FALSE;
-	}
-
-	g_mutex_lock(&priv->mutex);
-
-	if (priv->is_allocated) {
-		generate_local_error(error, HINOKO_FW_ISO_RESOURCE_AUTO_ERROR_ALLOCATED);
-		result = FALSE;
-		goto end;
-	}
-
-	for (i = 0; i < channel_candidates_count; ++i) {
-		if (channel_candidates[i] < 64)
-			res.channels |= 1ull << channel_candidates[i];
-	}
-	res.bandwidth = bandwidth;
-
-	if (ioctl(priv->state.fd, FW_CDEV_IOC_ALLOCATE_ISO_RESOURCE, &res) < 0) {
-		generate_ioctl_error(error, errno, FW_CDEV_IOC_ALLOCATE_ISO_RESOURCE);
-		result = FALSE;
-	} else {
-		priv->handle = res.handle;
-		result = TRUE;
-	}
-end:
-	g_mutex_unlock(&priv->mutex);
-
-	return result;
+	return fw_iso_resource_auto_allocate_async(HINOKO_FW_ISO_RESOURCE(self),
+						   channel_candidates, channel_candidates_count,
+						   bandwidth, error);
 }
 
 /**

--- a/src/fw_iso_resource_auto.h
+++ b/src/fw_iso_resource_auto.h
@@ -21,17 +21,6 @@ struct _HinokoFwIsoResourceAutoClass {
 
 HinokoFwIsoResourceAuto *hinoko_fw_iso_resource_auto_new(void);
 
-gboolean hinoko_fw_iso_resource_auto_allocate_async(HinokoFwIsoResourceAuto *self,
-						    guint8 *channel_candidates,
-						    gsize channel_candidates_count,
-						    guint bandwidth,
-						    GError **error);
-gboolean hinoko_fw_iso_resource_auto_allocate_sync(HinokoFwIsoResourceAuto *self,
-					           guint8 *channel_candidates,
-					           gsize channel_candidates_count,
-					           guint bandwidth, guint timeout_ms,
-					           GError **error);
-
 gboolean hinoko_fw_iso_resource_auto_deallocate_async(HinokoFwIsoResourceAuto *self,
 						      GError **error);
 gboolean hinoko_fw_iso_resource_auto_deallocate_sync(HinokoFwIsoResourceAuto *self,

--- a/src/fw_iso_resource_once.c
+++ b/src/fw_iso_resource_once.c
@@ -183,6 +183,7 @@ static gboolean fw_iso_resource_once_create_source(HinokoFwIsoResource *inst, GS
 static void fw_iso_resource_iface_init(HinokoFwIsoResourceInterface *iface)
 {
 	iface->open = fw_iso_resource_once_open;
+	iface->allocate_async = fw_iso_resource_once_allocate_async;
 	iface->create_source = fw_iso_resource_once_create_source;
 
 }
@@ -199,32 +200,6 @@ static void fw_iso_resource_iface_init(HinokoFwIsoResourceInterface *iface)
 HinokoFwIsoResourceOnce *hinoko_fw_iso_resource_once_new()
 {
 	return g_object_new(HINOKO_TYPE_FW_ISO_RESOURCE_ONCE, NULL);
-}
-
-/**
- * hinoko_fw_iso_resource_once_allocate_async:
- * @self: A [class@FwIsoResourceOnce].
- * @channel_candidates: (array length=channel_candidates_count): The array with elements for
- *			numeric number for isochronous channel to be allocated.
- * @channel_candidates_count: The number of channel candidates.
- * @bandwidth: The amount of bandwidth to be allocated.
- * @error: A [struct@GLib.Error]. Error can be generated with domain of Hinoko.FwIsoResourceError.
- *
- * Initiate allocation of isochronous resource without any wait. When the allocation finishes,
- * [signal@FwIsoResource::allocated] signal is emit to notify the result, channel, and bandwidth.
- *
- * Returns: TRUE if the overall operation finishes successfully, otherwise FALSE.
- *
- * Since: 0.7.
- */
-gboolean hinoko_fw_iso_resource_once_allocate_async(HinokoFwIsoResourceOnce *self,
-						    guint8 *channel_candidates,
-						    gsize channel_candidates_count,
-						    guint bandwidth, GError **error)
-{
-	return fw_iso_resource_once_allocate_async(HINOKO_FW_ISO_RESOURCE(self),
-						   channel_candidates, channel_candidates_count,
-						   bandwidth, error);
 }
 
 /**
@@ -270,43 +245,6 @@ gboolean hinoko_fw_iso_resource_once_deallocate_async(HinokoFwIsoResourceOnce *s
 	}
 
 	return TRUE;
-}
-
-/**
- * hinoko_fw_iso_resource_once_allocate_sync:
- * @self: A [class@FwIsoResourceOnce].
- * @channel_candidates: (array length=channel_candidates_count): The array with elements for
- *			numeric number for isochronous channel to be allocated.
- * @channel_candidates_count: The number of channel candidates.
- * @bandwidth: The amount of bandwidth to be allocated.
- * @timeout_ms: The timeout to wait for allocated event.
- * @error: A [struct@GLib.Error]. Error can be generated with domain of Hinoko.FwIsoResourceError.
- *
- * Initiate allocation of isochronous resource and wait for [signal@FwIsoResource::allocated]
- * signal.
- *
- * Returns: TRUE if the overall operation finishes successfully, otherwise FALSE.
- *
- * Since: 0.7.
- */
-gboolean hinoko_fw_iso_resource_once_allocate_sync(HinokoFwIsoResourceOnce *self,
-						   guint8 *channel_candidates,
-					           gsize channel_candidates_count,
-					           guint bandwidth, guint timeout_ms,
-					           GError **error)
-{
-	struct fw_iso_resource_waiter w;
-
-	g_return_val_if_fail(HINOKO_IS_FW_ISO_RESOURCE_ONCE(self), FALSE);
-	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
-
-	fw_iso_resource_waiter_init(&w, HINOKO_FW_ISO_RESOURCE(self), ALLOCATED_SIGNAL_NAME,
-				    timeout_ms);
-
-	(void)hinoko_fw_iso_resource_once_allocate_async(self, channel_candidates,
-							 channel_candidates_count, bandwidth, error);
-
-	return fw_iso_resource_waiter_wait(&w, HINOKO_FW_ISO_RESOURCE(self), error);
 }
 
 /**

--- a/src/fw_iso_resource_once.h
+++ b/src/fw_iso_resource_once.h
@@ -17,19 +17,8 @@ struct _HinokoFwIsoResourceOnceClass {
 
 HinokoFwIsoResourceOnce *hinoko_fw_iso_resource_once_new();
 
-gboolean hinoko_fw_iso_resource_once_allocate_async(HinokoFwIsoResourceOnce *self,
-						    guint8 *channel_candidates,
-						    gsize channel_candidates_count,
-						    guint bandwidth, GError **error);
-
 gboolean hinoko_fw_iso_resource_once_deallocate_async(HinokoFwIsoResourceOnce *self, guint channel,
 						      guint bandwidth, GError **error);
-
-gboolean hinoko_fw_iso_resource_once_allocate_sync(HinokoFwIsoResourceOnce *self,
-						   guint8 *channel_candidates,
-					           gsize channel_candidates_count,
-					           guint bandwidth, guint timeout_ms,
-					           GError **error);
 
 gboolean hinoko_fw_iso_resource_once_deallocate_sync(HinokoFwIsoResourceOnce *self, guint channel,
 						     guint bandwidth, guint timeout_ms,

--- a/src/hinoko.map
+++ b/src/hinoko.map
@@ -73,17 +73,15 @@ HINOKO_0_7_0 {
     "hinoko_fw_iso_resource_get_type";
     "hinoko_fw_iso_resource_open";
     "hinoko_fw_iso_resource_create_source";
+    "hinoko_fw_iso_resource_allocate_async";
+    "hinoko_fw_iso_resource_allocate_sync";
 
     "hinoko_fw_iso_resource_auto_get_type";
-    "hinoko_fw_iso_resource_auto_allocate_async";
     "hinoko_fw_iso_resource_auto_deallocate_async";
-    "hinoko_fw_iso_resource_auto_allocate_sync";
     "hinoko_fw_iso_resource_auto_deallocate_sync";
 
     "hinoko_fw_iso_resource_once_get_type";
     "hinoko_fw_iso_resource_once_new";
-    "hinoko_fw_iso_resource_once_allocate_async";
     "hinoko_fw_iso_resource_once_deallocate_async";
-    "hinoko_fw_iso_resource_once_allocate_sync";
     "hinoko_fw_iso_resource_once_deallocate_sync";
 } HINOKO_0_5_0;


### PR DESCRIPTION
The signature for allocation API is the same in both of `Hinoko.FwIsoResourceAuto`
and `Hinoko.FwIsoResourceOnce`, therefore they can be defined as interface.

This patchset is for the purpose.

```
Takashi Sakamoto (4):
  fw_iso_resource_auto: code refactoring to split asynchronous allocation function
  fw_iso_resource_once: code refactoring to split asynchronous allocation function
  fw_iso_resource: add interface and implementation for resource allocation
  update README according to allocation interface

 README.rst                 |   9 ++-
 src/fw_iso_resource.c      |  73 +++++++++++++++++
 src/fw_iso_resource.h      |  14 ++++
 src/fw_iso_resource_auto.c | 160 ++++++++++++-------------------------
 src/fw_iso_resource_auto.h |  11 ---
 src/fw_iso_resource_once.c | 128 +++++++++--------------------
 src/fw_iso_resource_once.h |  11 ---
 src/hinoko.map             |   6 +-
 8 files changed, 185 insertions(+), 227 deletions(-)
```