### PR TITLE
[PATCH 0/7] use macro and helper/inline functions for predefined values

### DIFF
--- a/src/fw_iso_ctx.c
+++ b/src/fw_iso_ctx.c
@@ -44,7 +44,7 @@ static void hinoko_fw_iso_ctx_default_init(HinokoFwIsoCtxInterface *iface)
 	 *
 	 * Emitted when isochronous context is stopped.
 	 */
-	g_signal_new(STOPPED_SIGNAL_NEME,
+	g_signal_new(STOPPED_SIGNAL_NAME,
 		G_TYPE_FROM_INTERFACE(iface),
 		G_SIGNAL_RUN_LAST | G_SIGNAL_ACTION,
 		G_STRUCT_OFFSET(HinokoFwIsoCtxInterface, stopped),

--- a/src/fw_iso_ctx_private.c
+++ b/src/fw_iso_ctx_private.c
@@ -343,6 +343,21 @@ gboolean fw_iso_ctx_state_register_chunk(struct fw_iso_ctx_state *state, gboolea
 	return TRUE;
 }
 
+#define FW_CDEV_ISO_PACKET_CONTROL_HEADER_LENGTH_MASK	0xff000000
+#define FW_CDEV_ISO_PACKET_CONTROL_HEADER_LENGTH_SHIFT	24
+#define FW_CDEV_ISO_PACKET_CONTROL_PAYLOAD_MASK		0x0000ffff
+
+static guint fw_cdev_iso_packet_control_to_header_length(guint control)
+{
+	return (control & FW_CDEV_ISO_PACKET_CONTROL_HEADER_LENGTH_MASK) >>
+		FW_CDEV_ISO_PACKET_CONTROL_HEADER_LENGTH_SHIFT;
+}
+
+static guint fw_cdev_iso_packet_control_to_payload_length(guint control)
+{
+	return (control & FW_CDEV_ISO_PACKET_CONTROL_PAYLOAD_MASK);
+}
+
 /**
  * fw_iso_ctx_state_queue_chunks:
  * @state: A [struct@FwIsoCtxState].
@@ -374,8 +389,8 @@ gboolean fw_iso_ctx_state_queue_chunks(struct fw_iso_ctx_state *state, GError **
 
 			datum = (struct fw_cdev_iso_packet *)
 				(state->data + data_offset + data_length);
-			payload_length = datum->control & 0x0000ffff;
-			header_length = (datum->control & 0xff000000) >> 24;
+			payload_length = fw_cdev_iso_packet_control_to_payload_length(datum->control);
+			header_length = fw_cdev_iso_packet_control_to_header_length(datum->control);
 
 			if (buf_offset + buf_length + payload_length >
 							bytes_per_buffer) {

--- a/src/fw_iso_ctx_private.h
+++ b/src/fw_iso_ctx_private.h
@@ -50,6 +50,12 @@ static inline guint ohci1394_isoc_desc_tstamp_to_cycle(guint32 tstamp)
 	return (tstamp & OHCI1394_ISOC_DESC_timeStmap_CYCLE_MASK);
 }
 
+#define OHCI1394_IR_contextMatch_cycleMatch_MAX_SEC		3
+#define OHCI1394_IR_contextMatch_cycleMatch_MAX_CYCLE		7999
+
+#define OHCI1394_IT_contextControl_cycleMatch_MAX_SEC		3
+#define OHCI1394_IT_contextControl_cycleMatch_MAX_CYCLE		7999
+
 struct fw_iso_ctx_state {
 	int fd;
 	guint handle;

--- a/src/fw_iso_ctx_private.h
+++ b/src/fw_iso_ctx_private.h
@@ -35,6 +35,21 @@ static inline guint ieee1394_iso_header_to_data_length(guint iso_header)
 		IEEE1394_ISO_HEADER_DATA_LENGTH_SHIFT;
 }
 
+#define OHCI1394_ISOC_DESC_timeStamp_SEC_MASK		0x0000e000
+#define OHCI1394_ISOC_DESC_timeStamp_SEC_SHIFT		13
+#define OHCI1394_ISOC_DESC_timeStmap_CYCLE_MASK		0x00001fff
+
+static inline guint ohci1394_isoc_desc_tstamp_to_sec(guint32 tstamp)
+{
+	return (tstamp & OHCI1394_ISOC_DESC_timeStamp_SEC_MASK) >>
+							OHCI1394_ISOC_DESC_timeStamp_SEC_SHIFT;
+}
+
+static inline guint ohci1394_isoc_desc_tstamp_to_cycle(guint32 tstamp)
+{
+	return (tstamp & OHCI1394_ISOC_DESC_timeStmap_CYCLE_MASK);
+}
+
 struct fw_iso_ctx_state {
 	int fd;
 	guint handle;

--- a/src/fw_iso_ctx_private.h
+++ b/src/fw_iso_ctx_private.h
@@ -85,7 +85,7 @@ enum fw_iso_ctx_prop_type {
 #define BYTES_PER_CHUNK_PROP_NAME		"bytes-per-chunk"
 #define CHUNKS_PER_BUFFER_PROP_NAME		"chunks-per-buffer"
 
-#define STOPPED_SIGNAL_NEME		"stopped"
+#define STOPPED_SIGNAL_NAME			"stopped"
 
 void fw_iso_ctx_class_override_properties(GObjectClass *gobject_class);
 

--- a/src/fw_iso_ctx_private.h
+++ b/src/fw_iso_ctx_private.h
@@ -26,6 +26,14 @@ extern const char *const fw_iso_ctx_err_msgs[7];
 
 #define IEEE1394_MAX_CHANNEL			63
 #define IEEE1394_MAX_SYNC_CODE			15
+#define IEEE1394_ISO_HEADER_DATA_LENGTH_MASK	0xffff0000
+#define IEEE1394_ISO_HEADER_DATA_LENGTH_SHIFT	16
+
+static inline guint ieee1394_iso_header_to_data_length(guint iso_header)
+{
+	return (iso_header & IEEE1394_ISO_HEADER_DATA_LENGTH_MASK) >>
+		IEEE1394_ISO_HEADER_DATA_LENGTH_SHIFT;
+}
 
 struct fw_iso_ctx_state {
 	int fd;

--- a/src/fw_iso_ctx_private.h
+++ b/src/fw_iso_ctx_private.h
@@ -24,6 +24,9 @@ extern const char *const fw_iso_ctx_err_msgs[7];
 #define generate_file_error(error, code, format, arg) \
 	g_set_error(error, G_FILE_ERROR, code, format, arg)
 
+#define IEEE1394_MAX_CHANNEL			63
+#define IEEE1394_MAX_SYNC_CODE			15
+
 struct fw_iso_ctx_state {
 	int fd;
 	guint handle;
@@ -72,14 +75,14 @@ gboolean fw_iso_ctx_state_map_buffer(struct fw_iso_ctx_state *state, guint bytes
 void fw_iso_ctx_state_unmap_buffer(struct fw_iso_ctx_state *state);
 
 gboolean fw_iso_ctx_state_register_chunk(struct fw_iso_ctx_state *state, gboolean skip,
-					 HinokoFwIsoCtxMatchFlag tags, guint sy,
+					 HinokoFwIsoCtxMatchFlag tags, guint sync_code,
 					 const guint8 *header, guint header_length,
 					 guint payload_length, gboolean schedule_interrupt,
 					 GError **error);
 gboolean fw_iso_ctx_state_queue_chunks(struct fw_iso_ctx_state *state, GError **error);
 
 gboolean fw_iso_ctx_state_start(struct fw_iso_ctx_state *state, const guint16 *cycle_match,
-				guint32 sync, HinokoFwIsoCtxMatchFlag tags, GError **error);
+				guint32 sync_code, HinokoFwIsoCtxMatchFlag tags, GError **error);
 void fw_iso_ctx_state_stop(struct fw_iso_ctx_state *state);
 
 void fw_iso_ctx_state_read_frame(struct fw_iso_ctx_state *state, guint offset, guint length,

--- a/src/fw_iso_rx_multiple.c
+++ b/src/fw_iso_rx_multiple.c
@@ -261,7 +261,7 @@ gboolean fw_iso_rx_multiple_handle_event(HinokoFwIsoCtx *inst, const union fw_cd
 
 		buf = (const guint32 *)frames;
 		iso_header = GUINT32_FROM_LE(buf[0]);
-		length = (iso_header & 0xffff0000) >> 16;
+		length = ieee1394_iso_header_to_data_length(iso_header);
 
 		// In buffer-fill mode, payload is sandwitched by heading
 		// isochronous header and trailing timestamp.

--- a/src/fw_iso_rx_multiple.c
+++ b/src/fw_iso_rx_multiple.c
@@ -458,6 +458,10 @@ gboolean hinoko_fw_iso_rx_multiple_start(HinokoFwIsoRxMultiple *self, const guin
 	int i;
 
 	g_return_val_if_fail(HINOKO_IS_FW_ISO_RX_MULTIPLE(self), FALSE);
+	g_return_val_if_fail(cycle_match == NULL ||
+			     cycle_match[0] <= OHCI1394_IR_contextMatch_cycleMatch_MAX_SEC ||
+			     cycle_match[1] <= OHCI1394_IR_contextMatch_cycleMatch_MAX_CYCLE,
+			     FALSE);
 	g_return_val_if_fail(sync_code <= IEEE1394_MAX_SYNC_CODE, FALSE);
 	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
 

--- a/src/fw_iso_rx_multiple.c
+++ b/src/fw_iso_rx_multiple.c
@@ -131,7 +131,7 @@ static void fw_iso_rx_multiple_stop(HinokoFwIsoCtx *inst)
 	fw_iso_ctx_state_stop(&priv->state);
 
 	if (priv->state.running != running)
-		g_signal_emit_by_name(G_OBJECT(inst), "stopped", NULL);
+		g_signal_emit_by_name(G_OBJECT(inst), STOPPED_SIGNAL_NAME, NULL);
 }
 
 static void fw_iso_rx_multiple_unmap_buffer(HinokoFwIsoCtx *inst)

--- a/src/fw_iso_rx_multiple.h
+++ b/src/fw_iso_rx_multiple.h
@@ -34,7 +34,7 @@ gboolean hinoko_fw_iso_rx_multiple_map_buffer(HinokoFwIsoRxMultiple *self, guint
 					      guint chunks_per_buffer, GError **error);
 
 gboolean hinoko_fw_iso_rx_multiple_start(HinokoFwIsoRxMultiple *self, const guint16 *cycle_match,
-					 guint32 sync, HinokoFwIsoCtxMatchFlag tags,
+					 guint32 sync_code, HinokoFwIsoCtxMatchFlag tags,
 					 guint chunks_per_irq, GError **error);
 
 void hinoko_fw_iso_rx_multiple_get_payload(HinokoFwIsoRxMultiple *self, guint index,

--- a/src/fw_iso_rx_single.c
+++ b/src/fw_iso_rx_single.c
@@ -112,7 +112,7 @@ static void fw_iso_rx_single_stop(HinokoFwIsoCtx *inst)
 	fw_iso_ctx_state_stop(&priv->state);
 
 	if (priv->state.running != running)
-		g_signal_emit_by_name(G_OBJECT(inst), "stopped", NULL);
+		g_signal_emit_by_name(G_OBJECT(inst), STOPPED_SIGNAL_NAME, NULL);
 }
 
 static void fw_iso_rx_single_unmap_buffer(HinokoFwIsoCtx *inst)

--- a/src/fw_iso_rx_single.c
+++ b/src/fw_iso_rx_single.c
@@ -59,8 +59,8 @@ static void hinoko_fw_iso_rx_single_class_init(HinokoFwIsoRxSingleClass *klass)
 	/**
 	 * HinokoFwIsoRxSingle::interrupted:
 	 * @self: A [class@FwIsoRxSingle]
-	 * @sec: sec part of isochronous cycle when interrupt occurs.
-	 * @cycle: cycle part of of isochronous cycle when interrupt occurs.
+	 * @sec: sec part of isochronous cycle when interrupt occurs, up to 7.
+	 * @cycle: cycle part of of isochronous cycle when interrupt occurs, up to 7999.
 	 * @header: (array length=header_length) (element-type guint8): The headers of IR context
 	 *	    for handled packets.
 	 * @header_length: the number of bytes for @header.
@@ -183,8 +183,8 @@ gboolean fw_iso_rx_single_handle_event(HinokoFwIsoCtx *inst, const union fw_cdev
 	priv = hinoko_fw_iso_rx_single_get_instance_private(self);
 
 	ev = &event->iso_interrupt;
-	sec = (ev->cycle & 0x0000e000) >> 13;
-	cycle = ev->cycle & 0x00001fff;
+	sec = ohci1394_isoc_desc_tstamp_to_sec(ev->cycle);
+	cycle = ohci1394_isoc_desc_tstamp_to_cycle(ev->cycle);
 	count = ev->header_length / priv->header_size;
 
 	// TODO; handling error?

--- a/src/fw_iso_rx_single.c
+++ b/src/fw_iso_rx_single.c
@@ -394,7 +394,7 @@ void hinoko_fw_iso_rx_single_get_payload(HinokoFwIsoRxSingle *self, guint index,
 
 	pos = index * priv->header_size / 4;
 	iso_header = GUINT32_FROM_BE(priv->ev->header[pos]);
-	*length = (iso_header & 0xffff0000) >> 16;
+	*length = ieee1394_iso_header_to_data_length(iso_header);
 	if (*length > bytes_per_chunk)
 		*length = bytes_per_chunk;
 

--- a/src/fw_iso_rx_single.c
+++ b/src/fw_iso_rx_single.c
@@ -240,7 +240,8 @@ HinokoFwIsoRxSingle *hinoko_fw_iso_rx_single_new(void)
  * @self: A [class@FwIsoRxSingle].
  * @path: A path to any Linux FireWire character device.
  * @channel: An isochronous channel to listen, up to 63.
- * @header_size: The number of bytes for header of IR context.
+ * @header_size: The number of bytes for header of IR context, greater than 4 at least to include
+ *		 isochronous header.
  * @error: A [struct@GLib.Error].
  *
  * Allocate an IR context to 1394 OHCI controller for packet-per-buffer mode. A local node of the
@@ -258,6 +259,7 @@ gboolean hinoko_fw_iso_rx_single_allocate(HinokoFwIsoRxSingle *self, const char 
 
 	g_return_val_if_fail(HINOKO_IS_FW_ISO_RX_SINGLE(self), FALSE);
 	g_return_val_if_fail(channel <= IEEE1394_MAX_CHANNEL, FALSE);
+	g_return_val_if_fail(header_size >= 4, FALSE);
 	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
 
 	priv = hinoko_fw_iso_rx_single_get_instance_private(self);

--- a/src/fw_iso_rx_single.c
+++ b/src/fw_iso_rx_single.c
@@ -239,7 +239,7 @@ HinokoFwIsoRxSingle *hinoko_fw_iso_rx_single_new(void)
  * hinoko_fw_iso_rx_single_allocate:
  * @self: A [class@FwIsoRxSingle].
  * @path: A path to any Linux FireWire character device.
- * @channel: An isochronous channel to listen.
+ * @channel: An isochronous channel to listen, up to 63.
  * @header_size: The number of bytes for header of IR context.
  * @error: A [struct@GLib.Error].
  *
@@ -257,6 +257,7 @@ gboolean hinoko_fw_iso_rx_single_allocate(HinokoFwIsoRxSingle *self, const char 
 	HinokoFwIsoRxSinglePrivate *priv;
 
 	g_return_val_if_fail(HINOKO_IS_FW_ISO_RX_SINGLE(self), FALSE);
+	g_return_val_if_fail(channel <= IEEE1394_MAX_CHANNEL, FALSE);
 	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
 
 	priv = hinoko_fw_iso_rx_single_get_instance_private(self);
@@ -331,7 +332,7 @@ gboolean hinoko_fw_iso_rx_single_register_packet(HinokoFwIsoRxSingle *self,
  *		 to start packet processing. The first element should be the second part of
  *		 isochronous cycle, up to 3. The second element should be the cycle part of
  *		 isochronous cycle, up to 7999.
- * @sync: The value of sync field in isochronous header for packet processing, up to 15.
+ * @sync_code: The value of sy field in isochronous packet header for packet processing, up to 15.
  * @tags: The value of tag field in isochronous header for packet processing.
  * @error: A [struct@GLib.Error].
  *
@@ -342,18 +343,19 @@ gboolean hinoko_fw_iso_rx_single_register_packet(HinokoFwIsoRxSingle *self,
  * Since: 0.7.
  */
 gboolean hinoko_fw_iso_rx_single_start(HinokoFwIsoRxSingle *self, const guint16 *cycle_match,
-				       guint32 sync, HinokoFwIsoCtxMatchFlag tags, GError **error)
+				       guint32 sync_code, HinokoFwIsoCtxMatchFlag tags, GError **error)
 {
 	HinokoFwIsoRxSinglePrivate *priv;
 
 	g_return_val_if_fail(HINOKO_IS_FW_ISO_RX_SINGLE(self), FALSE);
+	g_return_val_if_fail(sync_code <= IEEE1394_MAX_SYNC_CODE, FALSE);
 	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
 
 	priv = hinoko_fw_iso_rx_single_get_instance_private(self);
 
 	priv->chunk_cursor = 0;
 
-	return fw_iso_ctx_state_start(&priv->state, cycle_match, sync, tags, error);
+	return fw_iso_ctx_state_start(&priv->state, cycle_match, sync_code, tags, error);
 }
 
 /**

--- a/src/fw_iso_rx_single.c
+++ b/src/fw_iso_rx_single.c
@@ -348,6 +348,10 @@ gboolean hinoko_fw_iso_rx_single_start(HinokoFwIsoRxSingle *self, const guint16 
 	HinokoFwIsoRxSinglePrivate *priv;
 
 	g_return_val_if_fail(HINOKO_IS_FW_ISO_RX_SINGLE(self), FALSE);
+	g_return_val_if_fail(cycle_match == NULL ||
+			     cycle_match[0] <= OHCI1394_IR_contextMatch_cycleMatch_MAX_SEC ||
+			     cycle_match[1] <= OHCI1394_IR_contextMatch_cycleMatch_MAX_CYCLE,
+			     FALSE);
 	g_return_val_if_fail(sync_code <= IEEE1394_MAX_SYNC_CODE, FALSE);
 	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
 

--- a/src/fw_iso_rx_single.h
+++ b/src/fw_iso_rx_single.h
@@ -17,8 +17,8 @@ struct _HinokoFwIsoRxSingleClass {
 	/**
 	 * HinokoFwIsoRxSingleClass::interrupted:
 	 * @self: A [class@FwIsoRxSingle].
-	 * @sec: sec part of isochronous cycle when interrupt occurs.
-	 * @cycle: cycle part of of isochronous cycle when interrupt occurs.
+	 * @sec: The sec part of isochronous cycle when interrupt occurs, up to 7.
+	 * @cycle: The cycle part of of isochronous cycle when interrupt occurs, up to 7999.
 	 * @header: (array length=header_length) (element-type guint8): The headers of IR context
 	 *	    for handled packets.
 	 * @header_length: the number of bytes for header.

--- a/src/fw_iso_rx_single.h
+++ b/src/fw_iso_rx_single.h
@@ -44,7 +44,8 @@ gboolean hinoko_fw_iso_rx_single_register_packet(HinokoFwIsoRxSingle *self,
 						 gboolean schedule_interrupt, GError **error);
 
 gboolean hinoko_fw_iso_rx_single_start(HinokoFwIsoRxSingle *self, const guint16 *cycle_match,
-				       guint32 sync, HinokoFwIsoCtxMatchFlag tags, GError **error);
+				       guint32 sync_code, HinokoFwIsoCtxMatchFlag tags,
+				       GError **error);
 
 void hinoko_fw_iso_rx_single_get_payload(HinokoFwIsoRxSingle *self, guint index,
 					 const guint8 **payload, guint *length);

--- a/src/fw_iso_tx.c
+++ b/src/fw_iso_tx.c
@@ -53,8 +53,8 @@ static void hinoko_fw_iso_tx_class_init(HinokoFwIsoTxClass *klass)
 	/**
 	 * HinokoFwIsoTx::interrupted:
 	 * @self: A [class@FwIsoTx].
-	 * @sec: sec part of isochronous cycle when interrupt occurs.
-	 * @cycle: cycle part of of isochronous cycle when interrupt occurs.
+	 * @sec: sec part of isochronous cycle when interrupt occurs, up to 7.
+	 * @cycle: cycle part of of isochronous cycle when interrupt occurs, up to 7999.
 	 * @tstamp: (array length=tstamp_length) (element-type guint8): A series of timestamps for
 	 *	    packets already handled.
 	 * @tstamp_length: the number of bytes for @tstamp.
@@ -175,8 +175,8 @@ gboolean fw_iso_tx_handle_event(HinokoFwIsoCtx *inst, const union fw_cdev_event 
 
 	ev = &event->iso_interrupt;
 
-	sec = (ev->cycle & 0x0000e000) >> 13;
-	cycle = ev->cycle & 0x00001fff;
+	sec = ohci1394_isoc_desc_tstamp_to_sec(ev->cycle);
+	cycle = ohci1394_isoc_desc_tstamp_to_cycle(ev->cycle);
 	pkt_count = ev->header_length / 4;
 
 	g_signal_emit(inst, fw_iso_tx_sigs[FW_ISO_TX_SIG_TYPE_IRQ], 0, sec, cycle, ev->header,

--- a/src/fw_iso_tx.c
+++ b/src/fw_iso_tx.c
@@ -297,6 +297,10 @@ gboolean hinoko_fw_iso_tx_start(HinokoFwIsoTx *self, const guint16 *cycle_match,
 	HinokoFwIsoTxPrivate *priv;
 
 	g_return_val_if_fail(HINOKO_IS_FW_ISO_TX(self), FALSE);
+	g_return_val_if_fail(cycle_match == NULL ||
+			     cycle_match[0] <= OHCI1394_IT_contextControl_cycleMatch_MAX_SEC ||
+			     cycle_match[1] <= OHCI1394_IT_contextControl_cycleMatch_MAX_CYCLE,
+			     FALSE);
 	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
 	priv = hinoko_fw_iso_tx_get_instance_private(self);
 

--- a/src/fw_iso_tx.c
+++ b/src/fw_iso_tx.c
@@ -103,7 +103,7 @@ static void fw_iso_tx_stop(HinokoFwIsoCtx *inst)
 	fw_iso_ctx_state_stop(&priv->state);
 
 	if (priv->state.running != running)
-		g_signal_emit_by_name(G_OBJECT(inst), "stopped", NULL);
+		g_signal_emit_by_name(G_OBJECT(inst), STOPPED_SIGNAL_NAME, NULL);
 }
 
 void fw_iso_tx_unmap_buffer(HinokoFwIsoCtx *inst)

--- a/src/fw_iso_tx.h
+++ b/src/fw_iso_tx.h
@@ -16,8 +16,8 @@ struct _HinokoFwIsoTxClass {
 	/**
 	 * HinokoFwIsoTxClass::interrupted:
 	 * @self: A [class@FwIsoTx].
-	 * @sec: sec part of isochronous cycle when interrupt occurs.
-	 * @cycle: cycle part of of isochronous cycle when interrupt occurs.
+	 * @sec: The sec part of isochronous cycle when interrupt occurs, up to 7.
+	 * @cycle: The cycle part of of isochronous cycle when interrupt occurs, up to 7999.
 	 * @tstamp: (array length=tstamp_length) (element-type guint8): A series of timestamps for
 	 *	    packets already handled.
 	 * @tstamp_length: the number of bytes for @tstamp.

--- a/src/fw_iso_tx.h
+++ b/src/fw_iso_tx.h
@@ -41,7 +41,7 @@ gboolean hinoko_fw_iso_tx_map_buffer(HinokoFwIsoTx *self, guint maximum_bytes_pe
 gboolean hinoko_fw_iso_tx_start(HinokoFwIsoTx *self, const guint16 *cycle_match, GError **error);
 
 gboolean hinoko_fw_iso_tx_register_packet(HinokoFwIsoTx *self, HinokoFwIsoCtxMatchFlag tags,
-					  guint sy,
+					  guint sync_code,
 					  const guint8 *header, guint header_length,
 					  const guint8 *payload, guint payload_length,
 					  gboolean schedule_interrupt, GError **error);


### PR DESCRIPTION
Current implementation includes some hard-coded numeric values defined in each
specifications. In convention of programming, it's preferable to code them with macro.

This patchset is for the purpose.

```
Takashi Sakamoto (7):
  fw_iso_ctx_private: add macro for maximum channel and sync code define in IEEE 1394
  fw_iso_ctx_private: add helper function to compute data length from isoc packet header
  cycle_timer: add helper functions to compute value of CYCLE_TIMER register
  fw_iso_ctx_private: add inline function to compute timeStamp field in IR/IT descriptors
  fw_iso_ctx_private: add macro and helper function for cycle match in IR/IT context
  fw_iso_ctx_private: add helper function for control of isoc packet
  fw_iso_ctx: use macro for signal name

 src/cycle_timer.c        | 31 ++++++++++++++--
 src/fw_iso_ctx.c         |  2 +-
 src/fw_iso_ctx_private.c | 80 +++++++++++++++++++++++++++-------------
 src/fw_iso_ctx_private.h | 38 +++++++++++++++++--
 src/fw_iso_rx_multiple.c | 21 +++++++----
 src/fw_iso_rx_multiple.h |  2 +-
 src/fw_iso_rx_single.c   | 26 ++++++++-----
 src/fw_iso_rx_single.h   |  7 ++--
 src/fw_iso_tx.c          | 27 +++++++++-----
 src/fw_iso_tx.h          |  6 +--
 10 files changed, 171 insertions(+), 69 deletions(-)
```