### PR TITLE
[PATCH 0/8] tests: refine test implementation

### DIFF
--- a/tests/cycle-timer
+++ b/tests/cycle-timer
@@ -9,7 +9,7 @@ import gi
 gi.require_version('Hinoko', '0.0')
 from gi.repository import Hinoko
 
-target = Hinoko.CycleTimer
+target_type = Hinoko.CycleTimer
 methods = (
     'new',
     'get_timestamp',
@@ -17,5 +17,5 @@ methods = (
     'get_cycle_timer',
 )
 
-if not test_struct(target, methods):
+if not test_struct(target_type,  methods):
     exit(ENXIO)

--- a/tests/cycle-timer
+++ b/tests/cycle-timer
@@ -1,0 +1,21 @@
+#!/usr/bin/env python3
+
+from sys import exit
+from errno import ENXIO
+
+from helper import test_struct
+
+import gi
+gi.require_version('Hinoko', '0.0')
+from gi.repository import Hinoko
+
+target = Hinoko.CycleTimer
+methods = (
+    'new',
+    'get_timestamp',
+    'get_clock_id',
+    'get_cycle_timer',
+)
+
+if not test_struct(target, methods):
+    exit(ENXIO)

--- a/tests/fw-iso-ctx
+++ b/tests/fw-iso-ctx
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+
+from sys import exit
+from errno import ENXIO
+
+from helper import test_object
+
+import gi
+gi.require_version('Hinoko', '0.0')
+from gi.repository import Hinoko
+
+target_type = Hinoko.FwIsoCtx
+props = (
+    'bytes-per-chunk',
+    'chunks-per-buffer',
+)
+methods = (
+    'stop',
+    'unmap_buffer',
+    'release',
+    'get_cycle_timer',
+    'create_source',
+    'flush_completions',
+)
+vmethods = (
+    'do_stop',
+    'do_unmap_buffer',
+    'do_release',
+    'do_get_cycle_timer',
+    'do_flush_completions',
+    'do_create_source',
+    'do_stopped',
+)
+signals = (
+    'stopped',
+)
+
+if not test_object(target_type,  props, methods, vmethods, signals):
+    exit(ENXIO)

--- a/tests/fw-iso-resource
+++ b/tests/fw-iso-resource
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+
+from sys import exit
+from errno import ENXIO
+
+from helper import test_object
+
+import gi
+gi.require_version('Hinoko', '0.0')
+from gi.repository import Hinoko
+
+target_type = Hinoko.FwIsoResource
+props = (
+    'generation',
+)
+methods = (
+    'open',
+    'create_source',
+    'allocate_async',
+    'allocate_sync',
+)
+vmethods = (
+    'do_open',
+    'do_allocate_async',
+    'do_create_source',
+    'do_allocated',
+    'do_deallocated',
+)
+signals = (
+    'allocated',
+    'deallocated',
+)
+
+if not test_object(target_type,  props, methods, vmethods, signals):
+    exit(ENXIO)

--- a/tests/fw-iso-resource-auto
+++ b/tests/fw-iso-resource-auto
@@ -14,24 +14,31 @@ props = (
     'is-allocated',
     'channel',
     'bandwidth',
+    # From interface.
     'generation',
 )
 methods = (
     'new',
+    'deallocate_async',
+    'deallocate_sync',
+    # From interface.
     'open',
     'create_source',
     'allocate_async',
-    'deallocate_async',
     'allocate_sync',
-    'deallocate_sync',
 )
 vmethods = (
-    #'do_allocated',
-    #'do_deallocated',
+    # From interface.
+    'do_open',
+    'do_allocate_async',
+    'do_create_source',
+    'do_allocated',
+    'do_deallocated',
 )
 signals = (
-    #'allocated',
-    #'deallocated',
+    # From interface.
+    'allocated',
+    'deallocated',
 )
 
 if not test_object(target_type,  props, methods, vmethods, signals):

--- a/tests/fw-iso-resource-auto
+++ b/tests/fw-iso-resource-auto
@@ -9,7 +9,7 @@ import gi
 gi.require_version('Hinoko', '0.0')
 from gi.repository import Hinoko
 
-target = Hinoko.FwIsoResourceAuto()
+target_type = Hinoko.FwIsoResourceAuto
 props = (
     'is-allocated',
     'channel',
@@ -34,6 +34,6 @@ signals = (
     #'deallocated',
 )
 
-if not test_object(target, props, methods, vmethods, signals):
+if not test_object(target_type,  props, methods, vmethods, signals):
     exit(ENXIO)
 

--- a/tests/fw-iso-resource-auto
+++ b/tests/fw-iso-resource-auto
@@ -3,7 +3,7 @@
 from sys import exit
 from errno import ENXIO
 
-from helper import test
+from helper import test_object
 
 import gi
 gi.require_version('Hinoko', '0.0')
@@ -34,6 +34,6 @@ signals = (
     #'deallocated',
 )
 
-if not test(target, props, methods, vmethods, signals):
+if not test_object(target, props, methods, vmethods, signals):
     exit(ENXIO)
 

--- a/tests/fw-iso-resource-once
+++ b/tests/fw-iso-resource-once
@@ -9,7 +9,7 @@ import gi
 gi.require_version('Hinoko', '0.0')
 from gi.repository import Hinoko
 
-target = Hinoko.FwIsoResourceOnce()
+target_type = Hinoko.FwIsoResourceOnce
 props = (
     'generation',
 )
@@ -32,6 +32,6 @@ signals = (
 )
 
 
-if not test_object(target, props, methods, vmethods, signals):
+if not test_object(target_type,  props, methods, vmethods, signals):
     exit(ENXIO)
 

--- a/tests/fw-iso-resource-once
+++ b/tests/fw-iso-resource-once
@@ -11,24 +11,28 @@ from gi.repository import Hinoko
 
 target_type = Hinoko.FwIsoResourceOnce
 props = (
+    # From interface.
     'generation',
 )
 methods = (
     'new',
+    'deallocate_async',
+    'deallocate_sync',
+    # From interface.
     'open',
     'create_source',
     'allocate_async',
-    'deallocate_async',
     'allocate_sync',
-    'deallocate_sync',
 )
 vmethods = (
-    #'do_allocated',
-    #'do_deallocated',
+    # From interface.
+    'do_allocated',
+    'do_deallocated',
 )
 signals = (
-    #'allocated',
-    #'deallocated',
+    # From interface.
+    'allocated',
+    'deallocated',
 )
 
 

--- a/tests/fw-iso-resource-once
+++ b/tests/fw-iso-resource-once
@@ -3,7 +3,7 @@
 from sys import exit
 from errno import ENXIO
 
-from helper import test
+from helper import test_object
 
 import gi
 gi.require_version('Hinoko', '0.0')
@@ -32,6 +32,6 @@ signals = (
 )
 
 
-if not test(target, props, methods, vmethods, signals):
+if not test_object(target, props, methods, vmethods, signals):
     exit(ENXIO)
 

--- a/tests/fw-iso-rx-multiple
+++ b/tests/fw-iso-rx-multiple
@@ -9,7 +9,7 @@ import gi
 gi.require_version('Hinoko', '0.0')
 from gi.repository import Hinoko
 
-target = Hinoko.FwIsoRxMultiple()
+target_type = Hinoko.FwIsoRxMultiple
 props = (
     'channels',
 )
@@ -30,5 +30,5 @@ signals = (
     'interrupted',
 )
 
-if not test_object(target, props, methods, vmethods, signals):
+if not test_object(target_type,  props, methods, vmethods, signals):
     exit(ENXIO)

--- a/tests/fw-iso-rx-multiple
+++ b/tests/fw-iso-rx-multiple
@@ -3,7 +3,7 @@
 from sys import exit
 from errno import ENXIO
 
-from helper import test
+from helper import test_object
 
 import gi
 gi.require_version('Hinoko', '0.0')
@@ -30,5 +30,5 @@ signals = (
     'interrupted',
 )
 
-if not test(target, props, methods, vmethods, signals):
+if not test_object(target, props, methods, vmethods, signals):
     exit(ENXIO)

--- a/tests/fw-iso-rx-multiple
+++ b/tests/fw-iso-rx-multiple
@@ -12,22 +12,39 @@ from gi.repository import Hinoko
 target_type = Hinoko.FwIsoRxMultiple
 props = (
     'channels',
+    # From interface.
+    'bytes-per-chunk',
+    'chunks-per-buffer',
 )
 methods = (
     'new',
     'allocate',
-    'release',
     'map_buffer',
-    'unmap_buffer',
     'start',
-    'stop',
     'get_payload',
+    # From interface.
+    'stop',
+    'unmap_buffer',
+    'release',
+    'get_cycle_timer',
+    'create_source',
+    'flush_completions',
 )
 vmethods = (
     'do_interrupted',
+    # From interface.
+    'do_stop',
+    'do_unmap_buffer',
+    'do_release',
+    'do_get_cycle_timer',
+    'do_flush_completions',
+    'do_create_source',
+    'do_stopped',
 )
 signals = (
     'interrupted',
+    # From interface.
+    'stopped',
 )
 
 if not test_object(target_type,  props, methods, vmethods, signals):

--- a/tests/fw-iso-rx-single
+++ b/tests/fw-iso-rx-single
@@ -10,23 +10,41 @@ gi.require_version('Hinoko', '0.0')
 from gi.repository import Hinoko
 
 target_type = Hinoko.FwIsoRxSingle
-props = ()
+props = (
+    # From interface.
+    'bytes-per-chunk',
+    'chunks-per-buffer',
+)
 methods = (
     'new',
     'allocate',
-    'release',
     'map_buffer',
-    'unmap_buffer',
-    'register_packet',
     'start',
-    'stop',
     'get_payload',
+    'register_packet',
+    # From interface.
+    'stop',
+    'unmap_buffer',
+    'release',
+    'get_cycle_timer',
+    'create_source',
+    'flush_completions',
 )
 vmethods = (
     'do_interrupted',
+    # From interface.
+    'do_stop',
+    'do_unmap_buffer',
+    'do_release',
+    'do_get_cycle_timer',
+    'do_flush_completions',
+    'do_create_source',
+    'do_stopped',
 )
 signals = (
     'interrupted',
+    # From interface.
+    'stopped',
 )
 
 if not test_object(target_type,  props, methods, vmethods, signals):

--- a/tests/fw-iso-rx-single
+++ b/tests/fw-iso-rx-single
@@ -9,7 +9,7 @@ import gi
 gi.require_version('Hinoko', '0.0')
 from gi.repository import Hinoko
 
-target = Hinoko.FwIsoRxSingle()
+target_type = Hinoko.FwIsoRxSingle
 props = ()
 methods = (
     'new',
@@ -29,5 +29,5 @@ signals = (
     'interrupted',
 )
 
-if not test_object(target, props, methods, vmethods, signals):
+if not test_object(target_type,  props, methods, vmethods, signals):
     exit(ENXIO)

--- a/tests/fw-iso-rx-single
+++ b/tests/fw-iso-rx-single
@@ -3,7 +3,7 @@
 from sys import exit
 from errno import ENXIO
 
-from helper import test
+from helper import test_object
 
 import gi
 gi.require_version('Hinoko', '0.0')
@@ -29,5 +29,5 @@ signals = (
     'interrupted',
 )
 
-if not test(target, props, methods, vmethods, signals):
+if not test_object(target, props, methods, vmethods, signals):
     exit(ENXIO)

--- a/tests/fw-iso-tx
+++ b/tests/fw-iso-tx
@@ -3,7 +3,7 @@
 from sys import exit
 from errno import ENXIO
 
-from helper import test
+from helper import test_object
 
 import gi
 gi.require_version('Hinoko', '0.0')
@@ -28,5 +28,5 @@ signals = (
     'interrupted',
 )
 
-if not test(target, props, methods, vmethods, signals):
+if not test_object(target, props, methods, vmethods, signals):
     exit(ENXIO)

--- a/tests/fw-iso-tx
+++ b/tests/fw-iso-tx
@@ -9,7 +9,7 @@ import gi
 gi.require_version('Hinoko', '0.0')
 from gi.repository import Hinoko
 
-target = Hinoko.FwIsoTx()
+target_type = Hinoko.FwIsoTx
 props = ()
 methods = (
     'new',
@@ -28,5 +28,5 @@ signals = (
     'interrupted',
 )
 
-if not test_object(target, props, methods, vmethods, signals):
+if not test_object(target_type,  props, methods, vmethods, signals):
     exit(ENXIO)

--- a/tests/fw-iso-tx
+++ b/tests/fw-iso-tx
@@ -10,22 +10,40 @@ gi.require_version('Hinoko', '0.0')
 from gi.repository import Hinoko
 
 target_type = Hinoko.FwIsoTx
-props = ()
+props = (
+    # From interface.
+    'bytes-per-chunk',
+    'chunks-per-buffer',
+)
 methods = (
     'new',
     'allocate',
-    'release',
     'map_buffer',
-    'unmap_buffer',
     'start',
-    'stop',
     'register_packet',
+    # From interface.
+    'stop',
+    'unmap_buffer',
+    'release',
+    'get_cycle_timer',
+    'create_source',
+    'flush_completions',
 )
 vmethods = (
     'do_interrupted',
+    # From interface.
+    'do_stop',
+    'do_unmap_buffer',
+    'do_release',
+    'do_get_cycle_timer',
+    'do_flush_completions',
+    'do_create_source',
+    'do_stopped',
 )
 signals = (
     'interrupted',
+    # From interface.
+    'stopped',
 )
 
 if not test_object(target_type,  props, methods, vmethods, signals):

--- a/tests/helper.py
+++ b/tests/helper.py
@@ -52,3 +52,11 @@ def test_struct(target_type: object, methods: tuple[str]) -> bool:
             print('Method {0} is not produced.'.format(method))
             return False
     return True
+
+
+def test_functions(target_type: object, functions: tuple[str]) -> bool:
+    for function in functions:
+        if not hasattr(target_type, function):
+            print('Function {0} is not produced.'.format(function))
+            return False
+    return True

--- a/tests/helper.py
+++ b/tests/helper.py
@@ -31,3 +31,11 @@ def test_enums(target_type: object, enumerations: tuple[str]) -> bool:
                 enumeration, target_type))
             return False
     return True
+
+
+def test_struct(target_type: object, methods: tuple[str]) -> bool:
+    for method in methods:
+        if not hasattr(target_type, method):
+            print('Method {0} is not produced.'.format(method))
+            return False
+    return True

--- a/tests/helper.py
+++ b/tests/helper.py
@@ -1,24 +1,37 @@
-import gi
-gi.require_version('GObject', '2.0')
-from gi.repository import GObject
-
-def test_object(target_type,  props, methods, vmethods, signals) ->bool:
-    labels = [prop.name for prop in target_type.props]
-    for prop in props:
-        if prop not in labels:
-            print('Property {0} is not produced.'.format(prop))
-            return False
+def test_object(target_type: object, props: tuple[str], methods: tuple[str],
+                vmethods: tuple[str], signals: tuple[str]) -> bool:
+    # All of available methods are put into the list of attribute.
     for method in methods:
-        if not hasattr(target_type,  method):
+        if not hasattr(target_type, method):
             print('Method {0} is not produced.'.format(method))
             return False
+
+    # The properties, virtual methods, and signals in interface are not put
+    # into the list of attribute in object implementing the interface.
+    prop_labels = []
+    vmethod_labels = []
+    signal_labels = []
+
+    # The  gi.ObjectInfo and gi.InterfaceInfo keeps them. Let's traverse them.
+    for info in target_type.__mro__:
+        if hasattr(info, '__info__'):
+            for prop in info.__info__.get_properties():
+                prop_labels.append(prop.get_name())
+            for vfunc in info.__info__.get_vfuncs():
+                vmethod_labels.append('do_' + vfunc.get_name())
+            for signal in info.__info__.get_signals():
+                signal_labels.append(signal.get_name())
+
+    for prop in props:
+        if prop not in prop_labels:
+            print('Property {0} is not produced.'.format(prop))
+            return False
     for vmethod in vmethods:
-        if not hasattr(target_type,  method):
+        if vmethod not in vmethod_labels:
             print('Vmethod {0} is not produced.'.format(vmethod))
             return False
-    labels = GObject.signal_list_names(target_type)
     for signal in signals:
-        if signal not in labels:
+        if signal not in signal_labels:
             print('Signal {0} is not produced.'.format(signal))
             return False
     return True

--- a/tests/helper.py
+++ b/tests/helper.py
@@ -2,21 +2,21 @@ import gi
 gi.require_version('GObject', '2.0')
 from gi.repository import GObject
 
-def test_object(target, props, methods, vmethods, signals) ->bool:
-    labels = [prop.name for prop in target.props]
+def test_object(target_type,  props, methods, vmethods, signals) ->bool:
+    labels = [prop.name for prop in target_type.props]
     for prop in props:
         if prop not in labels:
             print('Property {0} is not produced.'.format(prop))
             return False
     for method in methods:
-        if not hasattr(target, method):
+        if not hasattr(target_type,  method):
             print('Method {0} is not produced.'.format(method))
             return False
     for vmethod in vmethods:
-        if not hasattr(target, method):
+        if not hasattr(target_type,  method):
             print('Vmethod {0} is not produced.'.format(vmethod))
             return False
-    labels = GObject.signal_list_names(target)
+    labels = GObject.signal_list_names(target_type)
     for signal in signals:
         if signal not in labels:
             print('Signal {0} is not produced.'.format(signal))

--- a/tests/helper.py
+++ b/tests/helper.py
@@ -2,7 +2,7 @@ import gi
 gi.require_version('GObject', '2.0')
 from gi.repository import GObject
 
-def test(target, props, methods, vmethods, signals) ->bool:
+def test_object(target, props, methods, vmethods, signals) ->bool:
     labels = [prop.name for prop in target.props]
     for prop in props:
         if prop not in labels:

--- a/tests/helper.py
+++ b/tests/helper.py
@@ -22,3 +22,12 @@ def test_object(target, props, methods, vmethods, signals) ->bool:
             print('Signal {0} is not produced.'.format(signal))
             return False
     return True
+
+
+def test_enums(target_type: object, enumerations: tuple[str]) -> bool:
+    for enumeration in enumerations:
+        if not hasattr(target_type, enumeration):
+            print('Enumeration {0} is not produced for {1}.'.format(
+                enumeration, target_type))
+            return False
+    return True

--- a/tests/hinoko-enum
+++ b/tests/hinoko-enum
@@ -3,7 +3,7 @@
 from sys import exit
 from errno import ENXIO
 
-from helper import test_object
+from helper import test_enums
 
 import gi
 gi.require_version('Hinoko', '0.0')
@@ -64,8 +64,6 @@ types = {
     Hinoko.FwIsoCtxError: fw_iso_ctx_error_enumerations,
 }
 
-for obj, types in types.items():
-    for t in types:
-        if not hasattr(obj, t):
-            print('Enumerator {0} is not produced.'.format(t))
-            exit(ENXIO)
+for target_type, enumerations in types.items():
+    if not test_enums(target_type, enumerations):
+        exit(ENXIO)

--- a/tests/hinoko-enum
+++ b/tests/hinoko-enum
@@ -3,7 +3,7 @@
 from sys import exit
 from errno import ENXIO
 
-from helper import test
+from helper import test_object
 
 import gi
 gi.require_version('Hinoko', '0.0')

--- a/tests/hinoko-functions
+++ b/tests/hinoko-functions
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+
+from sys import exit
+from errno import ENXIO
+
+import gi
+gi.require_version('Hinoko', '0.0')
+from gi.repository import Hinoko
+
+from helper import test_functions
+
+types = {
+    Hinoko.FwIsoResource: (
+        'calculate_bandwidth',
+    ),
+    Hinoko.FwIsoCtxError: (
+        'quark',
+    ),
+    Hinoko.FwIsoResourceError: (
+        'quark',
+    ),
+    Hinoko.FwIsoResourceAutoError: (
+        'quark',
+    ),
+}
+
+for target_type, functions in types.items():
+    if not test_functions(target_type, functions):
+        exit(ENXIO)

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -5,6 +5,7 @@ tests = [
   'fw-iso-tx',
   'fw-iso-resource-auto',
   'fw-iso-resource-once',
+  'cycle-timer',
 ]
 
 envs = environment()

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -4,6 +4,7 @@ tests = [
   'fw-iso-rx-single',
   'fw-iso-rx-multiple',
   'fw-iso-tx',
+  'fw-iso-resource',
   'fw-iso-resource-auto',
   'fw-iso-resource-once',
   'cycle-timer',

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -8,6 +8,7 @@ tests = [
   'fw-iso-resource-auto',
   'fw-iso-resource-once',
   'cycle-timer',
+  'hinoko-functions',
 ]
 
 envs = environment()

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -1,5 +1,6 @@
 tests = [
   'hinoko-enum',
+  'fw-iso-ctx',
   'fw-iso-rx-single',
   'fw-iso-rx-multiple',
   'fw-iso-tx',


### PR DESCRIPTION
Current implementation of test just supports GObject-derived object,
enumerations, and flags. It's not possible to test the other types of
glib/gobject elements such as boxed structure.

This patchset refines test implementation. Some helper functions for
boxed structure and namespace/object functions are added. The existent
helper function is renamed as 'test_object' and rewritten to walk through
Python MRO hierarchy to check properties, virtual methods, and signals,
defined by both GObject-derived objects and interfaces.

I note that the tests are not done to execute actual symbols. They are just
to check they are available or not via interface described in metadata of
GObject Introspection.

```
Takashi Sakamoto (8):
  tests: rename helper function to test object interface
  tests: add helper function to test enumerations and flags
  tests: add test script for Hinoko.CycleTimer boxed structure
  tests: test object type instead of its instance
  tests: refine helper function to test object
  tests: add test script for Hinoko.FwIsoCtx interface
  tests: add test script for Hinoko.FwIsoResource interface
  tests: add test script for object functions

 tests/cycle-timer          | 21 +++++++++++++
 tests/fw-iso-ctx           | 39 +++++++++++++++++++++++
 tests/fw-iso-resource      | 35 +++++++++++++++++++++
 tests/fw-iso-resource-auto | 25 +++++++++------
 tests/fw-iso-resource-once | 22 +++++++------
 tests/fw-iso-rx-multiple   | 29 +++++++++++++----
 tests/fw-iso-rx-single     | 34 +++++++++++++++-----
 tests/fw-iso-tx            | 32 ++++++++++++++-----
 tests/helper.py            | 64 ++++++++++++++++++++++++++++++--------
 tests/hinoko-enum          | 10 +++---
 tests/hinoko-functions     | 29 +++++++++++++++++
 tests/meson.build          |  4 +++
 12 files changed, 286 insertions(+), 58 deletions(-)
 create mode 100644 tests/cycle-timer
 create mode 100644 tests/fw-iso-ctx
 create mode 100644 tests/fw-iso-resource
 create mode 100644 tests/hinoko-functions
```