### PR TITLE
[PATCH 0/3] meson: add support for subproject

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,12 +2,6 @@ name: Build test
 
 on: [push, pull_request]
 
-env:
-  KERNEL_ORG_WORKING_PATH: ${{ github.workspace }}/../kernel.org
-  LIBHINAWA_BUILD_PATH: $KERNEL_ORG_WORKING_PATH/libhinawa
-  LIBHINAWA_REPOSITORY_URL: https://github.com/alsa-project/libhinawa.git
-  LIBHINAWA_TAG: 2.6.0
-
 jobs:
   build_in_fedora_amd64_on_docker:
     runs-on: ubuntu-latest
@@ -20,28 +14,21 @@ jobs:
         dnf -y install @development-tools
         dnf -y install meson gobject-introspection-devel systemd-devel
         dnf -y install gi-docgen python3-gobject
-    # Satisfy the dependency on libhinawa.
-    - name: make directory specific to software in kernel.org.
-      run: |
-        mkdir $KERNEL_ORG_WORKING_PATH
-    - name: Clone repository of libhinawa.
-      run: |
-        git clone --depth 1 --branch "${LIBHINAWA_TAG}" "${LIBHINAWA_REPOSITORY_URL}" "${LIBHINAWA_BUILD_PATH}"
-    - name: Initialize to build libhinawa.
-      run: |
-        cd "${LIBHINAWA_BUILD_PATH}"
-        meson setup --prefix=/usr build
-    - name: Install libhinawa.
-      run: |
-        cd "${LIBHINAWA_BUILD_PATH}"
-        meson install -C build
-    - name: Test installation of libhinawa.
-      run: |
-        cd "${LIBHINAWA_BUILD_PATH}"
-        python3 tests/fw-node
-    # Test to build libhinoko.
     - name: Checkout repository.
       uses: actions/checkout@v3
+    - name: Create hinawa.wrap in subproject directory
+      run: |
+        mkdir subprojects
+        cat > subprojects/hinawa.wrap << EOF
+        [wrap-git]
+        directory = libhinawa
+        url = https://git.kernel.org/pub/scm/libs/ieee1394/libhinawa.git
+        revision = 2.6.1
+        depth = 1
+        
+        [provide]
+        hinawa = hinawa_dep
+        EOF
     - name: Initialization for build.
       run: |
         meson --prefix=/tmp. -Ddoc=true -Dwarning_level=3 . build
@@ -70,28 +57,21 @@ jobs:
         DEBIAN_FRONTEND=noninteractive apt-get install -y git build-essential
         DEBIAN_FRONTEND=noninteractive apt-get install -y meson ninja-build libglib2.0-dev gobject-introspection libgirepository1.0-dev
         DEBIAN_FRONTEND=noninteractive apt-get install -y gi-docgen python3-gi
-    # Satisfy the dependency on libhinawa.
-    - name: make directory specific to software in kernel.org.
-      run: |
-        mkdir $KERNEL_ORG_WORKING_PATH
-    - name: Clone repository of libhinawa.
-      run: |
-        git clone --depth 1 --branch "${LIBHINAWA_TAG}" "${LIBHINAWA_REPOSITORY_URL}" "${LIBHINAWA_BUILD_PATH}"
-    - name: Initialize to build libhinawa.
-      run: |
-        cd "${LIBHINAWA_BUILD_PATH}"
-        meson setup --prefix=/usr build
-    - name: Install libhinawa.
-      run: |
-        cd "${LIBHINAWA_BUILD_PATH}"
-        meson install -C build
-    - name: Test installation of libhinawa.
-      run: |
-        cd "${LIBHINAWA_BUILD_PATH}"
-        python3 tests/fw-node
-    # Test to build libhinoko.
     - name: Checkout repository.
       uses: actions/checkout@v3
+    - name: Create hinawa.wrap in subproject directory
+      run: |
+        mkdir subprojects
+        cat > subprojects/hinawa.wrap << EOF
+        [wrap-git]
+        directory = libhinawa
+        url = https://git.kernel.org/pub/scm/libs/ieee1394/libhinawa.git
+        revision = 2.6.1
+        depth = 1
+        
+        [provide]
+        hinawa = hinawa_dep
+        EOF
     - name: Initialization for build.
       run: |
         meson --prefix=/tmp. -Ddoc=true -Dwarning_level=3 . build

--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@
 The libhinoko project
 =====================
 
-2023/07/17
+2023/10/01
 Takashi Sakamoto
 
 Introduction
@@ -89,6 +89,39 @@ Supplemental information for language bindings
   libraries compatible with g-i.
 * `hinoko-rs <https://git.kernel.org/pub/scm/libs/ieee1394/hinoko-rs.git/>`_ includes crates to
   use these libraries.
+
+Meson subproject
+================
+
+This is a sample of wrap file to satisfy dependency on libhinoko by
+`Meson subprojects <https://mesonbuild.com/Subprojects.html>`_.
+
+::
+
+    $ cat subproject/hinoko.wrap
+    [wrap-git]
+    directory = hinoko
+    url = https://git.kernel.org/pub/scm/libs/ieee1394/libhinoko.git
+    revision = v0.9.0
+    depth = 1
+    
+    [provide]
+    hinoko = hinoko_dep
+
+After installation of the wrap file, the dependency can be solved by ``hinoko`` name since it is
+common in both pkg-config and the wrap file. The implicit or explicit fallback to subproject is
+available.
+
+::
+
+    $ cat meson.build
+    hinoko_dependency = dependency('hinoko',
+      version: '>=0.9.0'
+    )
+
+In the case of subproject, the wrap file for ``hinawa`` should be installed as well, since
+``hinoko`` depends on it. For ``hinawa.wrap``, please refer to README of
+[libhinawa](https://git.kernel.org/pub/scm/libs/ieee1394/libhinawa.git/).
 
 Loss of backward compatibility between v0.8/v0.9 releases
 =========================================================

--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@
 The libhinoko project
 =====================
 
-2023/10/01
+2023/10/03
 Takashi Sakamoto
 
 Introduction
@@ -60,7 +60,7 @@ How to build
 
 ::
 
-    $ meson (--prefix=directory-to-install) build
+    $ meson setup (--prefix=directory-to-install) build
     $ meson compile -C build
     $ meson install -C build
     ($ meson test -C build)
@@ -102,7 +102,7 @@ This is a sample of wrap file to satisfy dependency on libhinoko by
     [wrap-git]
     directory = hinoko
     url = https://git.kernel.org/pub/scm/libs/ieee1394/libhinoko.git
-    revision = v0.9.0
+    revision = v0.9.1
     depth = 1
     
     [provide]
@@ -116,7 +116,7 @@ available.
 
     $ cat meson.build
     hinoko_dependency = dependency('hinoko',
-      version: '>=0.9.0'
+      version: '>=0.9.1'
     )
 
 In the case of subproject, the wrap file for ``hinawa`` should be installed as well, since

--- a/doc/meson.build
+++ b/doc/meson.build
@@ -18,6 +18,11 @@ dependency('gi-docgen',
 )
 gidocgen = find_program('gi-docgen')
 
+subproject_dependent_args = []
+if hinawa_is_subproject
+  subproject_dependent_args = ['--add-include-path', hinawa_gir_dir]
+endif
+
 doc_dir = meson.project_name()
 
 custom_target('hinoko-doc',
@@ -26,13 +31,14 @@ custom_target('hinoko-doc',
   command: [
     gidocgen,
     'generate',
+    subproject_dependent_args,
     '--no-namespace-dir',
     '--config=@INPUT0@',
     '--output-dir=@OUTPUT@',
     '--content-dir=@0@'.format(meson.current_source_dir()),
     '@INPUT1@',
   ],
-  depend_files: [ ext_contents ],
+  depend_files: ext_contents,
   build_by_default: true,
   install: true,
   install_dir: join_paths(get_option('datadir'), 'doc'),

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('hinoko', 'c',
-  version: '0.9.0',
+  version: '0.9.1',
   license: 'LGPL-2.1+',
   meson_version: '>= 0.46.0',
 )

--- a/meson.build
+++ b/meson.build
@@ -13,6 +13,11 @@ hinawa_dependency = dependency('hinawa',
   version: '>=2.6.0'
 )
 
+hinawa_is_subproject = hinawa_dependency.type_name() != 'pkgconfig'
+if hinawa_is_subproject
+  hinawa_gir_dir = join_paths(meson.build_root(), 'subprojects', 'libhinawa', 'src')
+endif
+
 subdir('src')
 subdir('tests')
 

--- a/src/hinoko.h
+++ b/src/hinoko.h
@@ -8,7 +8,7 @@
 #include <linux/firewire-cdev.h>
 #include <linux/firewire-constants.h>
 
-#include <libhinawa/hinawa.h>
+#include <hinawa.h>
 
 #include <hinoko_sigs_marshal.h>
 

--- a/src/meson.build
+++ b/src/meson.build
@@ -101,3 +101,11 @@ hinoko_gir = gnome.generate_gir(myself,
 
 # For test.
 builddir = meson.current_build_dir()
+
+# For wrap dependency system.
+hinoko_dep = declare_dependency(
+  link_with: myself,
+  dependencies: dependencies,
+  sources: headers + marshallers + enums + hinoko_gir,
+  include_directories: include_directories('.')
+)

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -10,9 +10,16 @@ tests = [
   'hinoko-functions',
 ]
 
+ld_library_paths = [builddir]
+gi_typelib_path = [builddir]
+if hinawa_is_subproject
+  ld_library_paths += hinawa_gir_dir
+  gi_typelib_path += hinawa_gir_dir
+endif
+
 envs = environment()
-envs.append('LD_LIBRARY_PATH', builddir, separator : ':')
-envs.append('GI_TYPELIB_PATH', builddir, separator : ':')
+envs.append('LD_LIBRARY_PATH', ld_library_paths, separator : ':')
+envs.append('GI_TYPELIB_PATH', gi_typelib_path, separator : ':')
 
 foreach test : tests
   name = test
@@ -20,5 +27,6 @@ foreach test : tests
   prog = find_program(script)
   test(name, prog,
     env: envs,
+    depends: hinoko_gir,
   )
 endforeach


### PR DESCRIPTION
Current declaration in meson files does not allow user applications to utilize libhinoko by meson subproject. This is inconvenient. This series  declares libhinoko dependency for exposing purpose. The dependency is available by meson wrap in subproject.

Additionally, the support for meson subproject enables to satisfy libhinawa dependency without installing it. It is convenient for CI automation. This series includes changes in workflow of github actions.

```
Takashi Sakamoto (3):
  meson: subproject support
  ci: utilize meson subproject to satisfy dependency on libhinawa
  bump release version to 0.9.1

 .github/workflows/build.yml | 72 ++++++++++++++-----------------------
 README.rst                  | 37 +++++++++++++++++--
 doc/meson.build             |  8 ++++-
 meson.build                 |  7 +++-
 src/hinoko.h                |  2 +-
 src/meson.build             |  8 +++++
 tests/meson.build           | 12 +++++--
 7 files changed, 93 insertions(+), 53 deletions(-)
```