### PR TITLE
[PATCH 0/3] meson: declaration cleanup

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@
 The libhinoko project
 =====================
 
-2023/10/03
+2023/10/07
 Takashi Sakamoto
 
 Introduction
@@ -50,7 +50,7 @@ Dependencies
 Requirements to build
 =====================
 
-- Meson 0.46.0 or later
+- Meson 0.54.0 or later
 - Ninja
 - PyGObject (optional to run unit tests)
 - gi-docgen (optional to generate API documentation)

--- a/README.rst
+++ b/README.rst
@@ -50,7 +50,7 @@ Dependencies
 Requirements to build
 =====================
 
-- Meson 0.54.0 or later
+- Meson 0.56.0 or later
 - Ninja
 - PyGObject (optional to run unit tests)
 - gi-docgen (optional to generate API documentation)
@@ -98,7 +98,7 @@ This is a sample of wrap file to satisfy dependency on libhinoko by
 
 ::
 
-    $ cat subproject/hinoko.wrap
+    $ cat subprojects/hinoko.wrap
     [wrap-git]
     directory = hinoko
     url = https://git.kernel.org/pub/scm/libs/ieee1394/libhinoko.git

--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project('hinoko', 'c',
   version: '0.9.1',
   license: 'LGPL-2.1+',
-  meson_version: '>= 0.46.0',
+  meson_version: '>= 0.54.0',
 )
 
 version = meson.project_version().split('.')

--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project('hinoko', 'c',
   version: '0.9.1',
   license: 'LGPL-2.1+',
-  meson_version: '>= 0.54.0',
+  meson_version: '>= 0.58.0',
 )
 
 version = meson.project_version().split('.')
@@ -15,7 +15,7 @@ hinawa_dependency = dependency('hinawa',
 
 hinawa_is_subproject = hinawa_dependency.type_name() != 'pkgconfig'
 if hinawa_is_subproject
-  hinawa_gir_dir = join_paths(meson.build_root(), 'subprojects', 'libhinawa', 'src')
+  hinawa_gir_dir = join_paths(meson.global_build_root(), 'subprojects', 'libhinawa', 'src')
 endif
 
 subdir('src')

--- a/src/meson.build
+++ b/src/meson.build
@@ -109,3 +109,4 @@ hinoko_dep = declare_dependency(
   sources: headers + marshallers + enums + hinoko_gir,
   include_directories: include_directories('.')
 )
+meson.override_dependency('hinoko', hinoko_dep)

--- a/src/meson.build
+++ b/src/meson.build
@@ -99,9 +99,6 @@ hinoko_gir = gnome.generate_gir(myself,
   install: true,
 )
 
-# For test.
-builddir = meson.current_build_dir()
-
 # For wrap dependency system.
 hinoko_dep = declare_dependency(
   link_with: myself,

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -10,16 +10,15 @@ tests = [
   'hinoko-functions',
 ]
 
-ld_library_paths = [builddir]
-gi_typelib_path = [builddir]
+builddirs = []
+builddirs += join_paths(meson.project_build_root(), 'src')
 if hinawa_is_subproject
-  ld_library_paths += hinawa_gir_dir
-  gi_typelib_path += hinawa_gir_dir
+  builddirs += hinawa_gir_dir
 endif
 
 envs = environment()
-envs.append('LD_LIBRARY_PATH', ld_library_paths, separator : ':')
-envs.append('GI_TYPELIB_PATH', gi_typelib_path, separator : ':')
+envs.append('LD_LIBRARY_PATH', builddirs, separator : ':')
+envs.append('GI_TYPELIB_PATH', builddirs, separator : ':')
 
 foreach test : tests
   name = test


### PR DESCRIPTION
The recent version of meson build gained some useful features. This series follows to it.

```
Takashi Sakamoto (3):
  meson: bump minimal version up to 0.54.0 for  meson.override_dependency()
  meson: bump minimal version up to 0.56.0 for meson.global_build_root()
  meson: use meson.project_build_root() to find built targets for test

 README.rst        |  6 +++---
 meson.build       |  4 ++--
 src/meson.build   |  4 +---
 tests/meson.build | 11 +++++------
 4 files changed, 11 insertions(+), 14 deletions(-)
```