### PR TITLE
[PATCH 0/4] fw_iso_resource: remove async/sync suffixes from allocation/deallocation methods

### DIFF
--- a/samples/iso-resource
+++ b/samples/iso-resource
@@ -48,7 +48,7 @@ for i in range(2):
     sleep(2)
 
     try:
-        res.deallocate_sync(use_channel, use_bandwidth, 100)
+        res.deallocate_wait(use_channel, use_bandwidth, 100)
     except GLib.Error as e:
         if e.matches(Hinoko.fw_iso_resource_error_quark(), Hinoko.FwIsoResourceError.EVENT):
             print(e)

--- a/samples/iso-resource
+++ b/samples/iso-resource
@@ -91,7 +91,7 @@ for i in range(2):
     sleep(1)
 
     try:
-        res.deallocate_sync(100)
+        res.deallocate_wait(100)
     except GLib.Error as e:
         if e.matches(Hinoko.fw_iso_resource_error_quark(), Hinoko.FwIsoResourceError.EVENT):
             print(e)

--- a/samples/iso-resource
+++ b/samples/iso-resource
@@ -37,7 +37,7 @@ src.attach(ctx)
 
 for i in range(2):
     try:
-        res.allocate_sync((use_channel, ), use_bandwidth, 100)
+        res.allocate_wait((use_channel, ), use_bandwidth, 100)
     except GLib.Error as e:
         if e.matches(Hinoko.fw_iso_resource_error_quark(), Hinoko.FwIsoResourceError.EVENT):
             print(e)
@@ -80,7 +80,7 @@ for i in range(2):
     print_props(res)
 
     try:
-        res.allocate_sync([use_channel], use_bandwidth, 100)
+        res.allocate_wait([use_channel], use_bandwidth, 100)
     except GLib.Error as e:
         if e.matches(Hinoko.fw_iso_resource_error_quark(), Hinoko.FwIsoResourceError.EVENT):
             print(e)

--- a/src/fw_iso_resource.c
+++ b/src/fw_iso_resource.c
@@ -202,7 +202,7 @@ gboolean hinoko_fw_iso_resource_allocate_async(HinokoFwIsoResource *self,
 }
 
 /**
- * hinoko_fw_iso_resource_allocate_sync:
+ * hinoko_fw_iso_resource_allocate_wait:
  * @self: A [iface@FwIsoResource].
  * @channel_candidates: (array length=channel_candidates_count): The array with elements for
  *			numeric number for isochronous channel to be allocated.
@@ -217,9 +217,9 @@ gboolean hinoko_fw_iso_resource_allocate_async(HinokoFwIsoResource *self,
  *
  * Returns: TRUE if the overall operation finishes successfully, otherwise FALSE.
  *
- * Since: 0.7
+ * Since: 1.0
  */
-gboolean hinoko_fw_iso_resource_allocate_sync(HinokoFwIsoResource *self,
+gboolean hinoko_fw_iso_resource_allocate_wait(HinokoFwIsoResource *self,
 					      const guint8 *channel_candidates,
 				              gsize channel_candidates_count, guint bandwidth,
 					      guint timeout_ms, GError **error)

--- a/src/fw_iso_resource.c
+++ b/src/fw_iso_resource.c
@@ -168,7 +168,7 @@ gboolean hinoko_fw_iso_resource_create_source(HinokoFwIsoResource *self, GSource
 }
 
 /**
- * hinoko_fw_iso_resource_allocate_async:
+ * hinoko_fw_iso_resource_allocate:
  * @self: A [iface@FwIsoResource].
  * @channel_candidates: (array length=channel_candidates_count): The array with elements for
  *			numeric number of isochronous channel to be allocated.
@@ -183,12 +183,12 @@ gboolean hinoko_fw_iso_resource_create_source(HinokoFwIsoResource *self, GSource
  *
  * Returns: TRUE if the overall operation finishes successfully, otherwise FALSE.
  *
- * Since: 0.7
+ * Since: 1.0
  */
-gboolean hinoko_fw_iso_resource_allocate_async(HinokoFwIsoResource *self,
-					       const guint8 *channel_candidates,
-					       gsize channel_candidates_count,
-					       guint bandwidth, GError **error)
+gboolean hinoko_fw_iso_resource_allocate(HinokoFwIsoResource *self,
+					 const guint8 *channel_candidates,
+					 gsize channel_candidates_count, guint bandwidth,
+					 GError **error)
 {
 	g_return_val_if_fail(HINOKO_IS_FW_ISO_RESOURCE(self), FALSE);
 	g_return_val_if_fail(channel_candidates != NULL, FALSE);
@@ -196,9 +196,9 @@ gboolean hinoko_fw_iso_resource_allocate_async(HinokoFwIsoResource *self,
 	g_return_val_if_fail(bandwidth > 0, FALSE);
 	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
 
-	return HINOKO_FW_ISO_RESOURCE_GET_IFACE(self)->allocate_async(self, channel_candidates,
-								      channel_candidates_count,
-								      bandwidth, error);
+	return HINOKO_FW_ISO_RESOURCE_GET_IFACE(self)->allocate(self, channel_candidates,
+								channel_candidates_count,
+								bandwidth, error);
 }
 
 /**
@@ -234,8 +234,8 @@ gboolean hinoko_fw_iso_resource_allocate_wait(HinokoFwIsoResource *self,
 
 	fw_iso_resource_waiter_init(&w, self, ALLOCATED_SIGNAL_NAME, timeout_ms);
 
-	(void)hinoko_fw_iso_resource_allocate_async(self, channel_candidates,
-						    channel_candidates_count, bandwidth, error);
+	(void)hinoko_fw_iso_resource_allocate(self, channel_candidates, channel_candidates_count,
+					      bandwidth, error);
 
 	return fw_iso_resource_waiter_wait(&w, self, error);
 }

--- a/src/fw_iso_resource.h
+++ b/src/fw_iso_resource.h
@@ -111,7 +111,7 @@ gboolean hinoko_fw_iso_resource_allocate_async(HinokoFwIsoResource *self,
 					       gsize channel_candidates_count,
 					       guint bandwidth, GError **error);
 
-gboolean hinoko_fw_iso_resource_allocate_sync(HinokoFwIsoResource *self,
+gboolean hinoko_fw_iso_resource_allocate_wait(HinokoFwIsoResource *self,
 					      const guint8 *channel_candidates,
 				              gsize channel_candidates_count, guint bandwidth,
 					      guint timeout_ms, GError **error);

--- a/src/fw_iso_resource.h
+++ b/src/fw_iso_resource.h
@@ -36,7 +36,7 @@ struct _HinokoFwIsoResourceInterface {
 			 GError **error);
 
 	/**
-	 * HinokoFwIsoResourceInterface::allocate_async:
+	 * HinokoFwIsoResourceInterface::allocate:
 	 * @self: A [iface@FwIsoResource].
 	 * @channel_candidates: (array length=channel_candidates_count): The array with elements for
 	 *			numeric number of isochronous channel to be allocated.
@@ -49,10 +49,10 @@ struct _HinokoFwIsoResourceInterface {
 	 *
 	 * Returns: TRUE if the overall operation finished successfully, otherwise FALSE.
 	 *
-	 * Since: 0.7
+	 * Since: 1.0
 	 */
-	gboolean (*allocate_async)(HinokoFwIsoResource *self, const guint8 *channel_candidates,
-				   gsize channel_candidates_count, guint bandwidth, GError **error);
+	gboolean (*allocate)(HinokoFwIsoResource *self, const guint8 *channel_candidates,
+			     gsize channel_candidates_count, guint bandwidth, GError **error);
 
 	/**
 	 * HinokoFwIsoResourceInterface::create_source:
@@ -106,10 +106,10 @@ gboolean hinoko_fw_iso_resource_open(HinokoFwIsoResource *self, const gchar *pat
 gboolean hinoko_fw_iso_resource_create_source(HinokoFwIsoResource *self, GSource **source,
 					      GError **error);
 
-gboolean hinoko_fw_iso_resource_allocate_async(HinokoFwIsoResource *self,
-					       const guint8 *channel_candidates,
-					       gsize channel_candidates_count,
-					       guint bandwidth, GError **error);
+gboolean hinoko_fw_iso_resource_allocate(HinokoFwIsoResource *self,
+					 const guint8 *channel_candidates,
+					 gsize channel_candidates_count, guint bandwidth,
+					 GError **error);
 
 gboolean hinoko_fw_iso_resource_allocate_wait(HinokoFwIsoResource *self,
 					      const guint8 *channel_candidates,

--- a/src/fw_iso_resource_auto.c
+++ b/src/fw_iso_resource_auto.c
@@ -360,7 +360,7 @@ HinokoFwIsoResourceAuto *hinoko_fw_iso_resource_auto_new()
 }
 
 /**
- * hinoko_fw_iso_resource_auto_deallocate_async:
+ * hinoko_fw_iso_resource_auto_deallocate:
  * @self: A [class@FwIsoResourceAuto]
  * @error: A [struct@GLib.Error]. Error can be generated with domains of [error@FwIsoResourceError],
  *	   and [error@FwIsoResourceAutoError].
@@ -370,10 +370,9 @@ HinokoFwIsoResourceAuto *hinoko_fw_iso_resource_auto_new()
  *
  * Returns: TRUE if the overall operation finished successfully, otherwise FALSE.
  *
- * Since: 0.7
+ * Since: 1.0
  */
-gboolean hinoko_fw_iso_resource_auto_deallocate_async(HinokoFwIsoResourceAuto *self,
-						      GError **error)
+gboolean hinoko_fw_iso_resource_auto_deallocate(HinokoFwIsoResourceAuto *self, GError **error)
 {
 	HinokoFwIsoResourceAutoPrivate *priv;
 	struct fw_cdev_deallocate dealloc = {0};
@@ -412,7 +411,7 @@ end:
 }
 
 /**
- * hinoko_fw_iso_resource_auto_deallocate_sync:
+ * hinoko_fw_iso_resource_auto_deallocate_wait:
  * @self: A [class@FwIsoResourceAuto]
  * @timeout_ms: The timeout to wait for allocated event by milli second unit.
  * @error: A [struct@GLib.Error]. Error can be generated with domains of [error@FwIsoResourceError],
@@ -423,9 +422,9 @@ end:
  *
  * Returns: TRUE if the overall operation finished successfully, otherwise FALSE.
  *
- * Since: 0.7
+ * Since: 1.0
  */
-gboolean hinoko_fw_iso_resource_auto_deallocate_sync(HinokoFwIsoResourceAuto *self,
+gboolean hinoko_fw_iso_resource_auto_deallocate_wait(HinokoFwIsoResourceAuto *self,
 						     guint timeout_ms, GError **error)
 {
 	struct fw_iso_resource_waiter w;
@@ -436,7 +435,7 @@ gboolean hinoko_fw_iso_resource_auto_deallocate_sync(HinokoFwIsoResourceAuto *se
 	fw_iso_resource_waiter_init(&w, HINOKO_FW_ISO_RESOURCE(self), DEALLOCATED_SIGNAL_NAME,
 				    timeout_ms);
 
-	(void)hinoko_fw_iso_resource_auto_deallocate_async(self, error);
+	(void)hinoko_fw_iso_resource_auto_deallocate(self, error);
 
 	return fw_iso_resource_waiter_wait(&w, HINOKO_FW_ISO_RESOURCE(self), error);
 }

--- a/src/fw_iso_resource_auto.c
+++ b/src/fw_iso_resource_auto.c
@@ -190,11 +190,10 @@ static gboolean fw_iso_resource_auto_open(HinokoFwIsoResource *inst, const gchar
 	return fw_iso_resource_state_open(&priv->state, path, open_flag, error);
 }
 
-static gboolean fw_iso_resource_auto_allocate_async(HinokoFwIsoResource *inst,
-						    const guint8 *channel_candidates,
-						    gsize channel_candidates_count,
-						    guint bandwidth,
-						    GError **error)
+static gboolean fw_iso_resource_auto_allocate(HinokoFwIsoResource *inst,
+					      const guint8 *channel_candidates,
+					      gsize channel_candidates_count, guint bandwidth,
+					      GError **error)
 {
 	HinokoFwIsoResourceAuto *self;
 	HinokoFwIsoResourceAutoPrivate *priv;
@@ -342,7 +341,7 @@ static gboolean fw_iso_resource_auto_create_source(HinokoFwIsoResource *inst, GS
 static void fw_iso_resource_iface_init(HinokoFwIsoResourceInterface *iface)
 {
 	iface->open = fw_iso_resource_auto_open;
-	iface->allocate_async = fw_iso_resource_auto_allocate_async;
+	iface->allocate = fw_iso_resource_auto_allocate;
 	iface->create_source = fw_iso_resource_auto_create_source;
 
 }

--- a/src/fw_iso_resource_auto.h
+++ b/src/fw_iso_resource_auto.h
@@ -21,9 +21,8 @@ struct _HinokoFwIsoResourceAutoClass {
 
 HinokoFwIsoResourceAuto *hinoko_fw_iso_resource_auto_new(void);
 
-gboolean hinoko_fw_iso_resource_auto_deallocate_async(HinokoFwIsoResourceAuto *self,
-						      GError **error);
-gboolean hinoko_fw_iso_resource_auto_deallocate_sync(HinokoFwIsoResourceAuto *self,
+gboolean hinoko_fw_iso_resource_auto_deallocate(HinokoFwIsoResourceAuto *self, GError **error);
+gboolean hinoko_fw_iso_resource_auto_deallocate_wait(HinokoFwIsoResourceAuto *self,
 						     guint timeout_ms, GError **error);
 
 G_END_DECLS

--- a/src/fw_iso_resource_once.c
+++ b/src/fw_iso_resource_once.c
@@ -71,10 +71,10 @@ static gboolean fw_iso_resource_once_open(HinokoFwIsoResource *inst, const gchar
 	return fw_iso_resource_state_open(&priv->state, path, open_flag, error);
 }
 
-static gboolean fw_iso_resource_once_allocate_async(HinokoFwIsoResource *inst,
-						    const guint8 *channel_candidates,
-						    gsize channel_candidates_count,
-						    guint bandwidth, GError **error)
+static gboolean fw_iso_resource_once_allocate(HinokoFwIsoResource *inst,
+					      const guint8 *channel_candidates,
+					      gsize channel_candidates_count,
+					      guint bandwidth, GError **error)
 {
 	HinokoFwIsoResourceOnce *self;
 	HinokoFwIsoResourceOncePrivate *priv;
@@ -183,7 +183,7 @@ static gboolean fw_iso_resource_once_create_source(HinokoFwIsoResource *inst, GS
 static void fw_iso_resource_iface_init(HinokoFwIsoResourceInterface *iface)
 {
 	iface->open = fw_iso_resource_once_open;
-	iface->allocate_async = fw_iso_resource_once_allocate_async;
+	iface->allocate = fw_iso_resource_once_allocate;
 	iface->create_source = fw_iso_resource_once_create_source;
 
 }

--- a/src/fw_iso_resource_once.c
+++ b/src/fw_iso_resource_once.c
@@ -203,7 +203,7 @@ HinokoFwIsoResourceOnce *hinoko_fw_iso_resource_once_new()
 }
 
 /**
- * hinoko_fw_iso_resource_once_deallocate_async:
+ * hinoko_fw_iso_resource_once_deallocate:
  * @self: A [class@FwIsoResourceOnce].
  * @channel: The channel number to be deallocated.
  * @bandwidth: The amount of bandwidth to be deallocated.
@@ -215,10 +215,10 @@ HinokoFwIsoResourceOnce *hinoko_fw_iso_resource_once_new()
  *
  * Returns: TRUE if the overall operation finishes successfully, otherwise FALSE.
  *
- * Since: 0.7
+ * Since: 1.0
  */
-gboolean hinoko_fw_iso_resource_once_deallocate_async(HinokoFwIsoResourceOnce *self, guint channel,
-						      guint bandwidth, GError **error)
+gboolean hinoko_fw_iso_resource_once_deallocate(HinokoFwIsoResourceOnce *self, guint channel,
+						guint bandwidth, GError **error)
 {
 	HinokoFwIsoResourceOncePrivate *priv;
 
@@ -248,7 +248,7 @@ gboolean hinoko_fw_iso_resource_once_deallocate_async(HinokoFwIsoResourceOnce *s
 }
 
 /**
- * hinoko_fw_iso_resource_once_deallocate_sync:
+ * hinoko_fw_iso_resource_once_deallocate_wait:
  * @self: A [class@FwIsoResourceOnce].
  * @channel: The channel number to be deallocated.
  * @bandwidth: The amount of bandwidth to be deallocated.
@@ -260,9 +260,9 @@ gboolean hinoko_fw_iso_resource_once_deallocate_async(HinokoFwIsoResourceOnce *s
  *
  * Returns: TRUE if the overall operation finishes successfully, otherwise FALSE.
  *
- * Since: 0.7
+ * Since: 1.0
  */
-gboolean hinoko_fw_iso_resource_once_deallocate_sync(HinokoFwIsoResourceOnce *self, guint channel,
+gboolean hinoko_fw_iso_resource_once_deallocate_wait(HinokoFwIsoResourceOnce *self, guint channel,
 						     guint bandwidth, guint timeout_ms,
 						     GError **error)
 {
@@ -274,7 +274,7 @@ gboolean hinoko_fw_iso_resource_once_deallocate_sync(HinokoFwIsoResourceOnce *se
 	fw_iso_resource_waiter_init(&w, HINOKO_FW_ISO_RESOURCE(self), DEALLOCATED_SIGNAL_NAME,
 				    timeout_ms);
 
-	(void)hinoko_fw_iso_resource_once_deallocate_async(self, channel, bandwidth, error);
+	(void)hinoko_fw_iso_resource_once_deallocate(self, channel, bandwidth, error);
 
 	return fw_iso_resource_waiter_wait(&w, HINOKO_FW_ISO_RESOURCE(self), error);
 }

--- a/src/fw_iso_resource_once.h
+++ b/src/fw_iso_resource_once.h
@@ -17,10 +17,10 @@ struct _HinokoFwIsoResourceOnceClass {
 
 HinokoFwIsoResourceOnce *hinoko_fw_iso_resource_once_new();
 
-gboolean hinoko_fw_iso_resource_once_deallocate_async(HinokoFwIsoResourceOnce *self, guint channel,
-						      guint bandwidth, GError **error);
+gboolean hinoko_fw_iso_resource_once_deallocate(HinokoFwIsoResourceOnce *self, guint channel,
+						guint bandwidth, GError **error);
 
-gboolean hinoko_fw_iso_resource_once_deallocate_sync(HinokoFwIsoResourceOnce *self, guint channel,
+gboolean hinoko_fw_iso_resource_once_deallocate_wait(HinokoFwIsoResourceOnce *self, guint channel,
 						     guint bandwidth, guint timeout_ms,
 						     GError **error);
 

--- a/src/hinoko.map
+++ b/src/hinoko.map
@@ -45,8 +45,6 @@ HINOKO_0_7_0 {
     "hinoko_fw_iso_resource_allocate_sync";
 
     "hinoko_fw_iso_resource_auto_get_type";
-    "hinoko_fw_iso_resource_auto_deallocate_async";
-    "hinoko_fw_iso_resource_auto_deallocate_sync";
 
     "hinoko_fw_iso_resource_once_get_type";
     "hinoko_fw_iso_resource_once_new";
@@ -83,4 +81,7 @@ HINOKO_0_9_0 {
 HINOKO_1_0_0 {
     "hinoko_fw_iso_resource_once_deallocate";
     "hinoko_fw_iso_resource_once_deallocate_wait";
+
+    "hinoko_fw_iso_resource_auto_deallocate";
+    "hinoko_fw_iso_resource_auto_deallocate_wait";
 } HINOKO_0_9_0;

--- a/src/hinoko.map
+++ b/src/hinoko.map
@@ -41,7 +41,6 @@ HINOKO_0_7_0 {
     "hinoko_fw_iso_resource_get_type";
     "hinoko_fw_iso_resource_open";
     "hinoko_fw_iso_resource_create_source";
-    "hinoko_fw_iso_resource_allocate_async";
 
     "hinoko_fw_iso_resource_auto_get_type";
 
@@ -78,6 +77,7 @@ HINOKO_0_9_0 {
 } HINOKO_0_8_0;
 
 HINOKO_1_0_0 {
+    "hinoko_fw_iso_resource_allocate";
     "hinoko_fw_iso_resource_allocate_wait";
 
     "hinoko_fw_iso_resource_once_deallocate";

--- a/src/hinoko.map
+++ b/src/hinoko.map
@@ -42,7 +42,6 @@ HINOKO_0_7_0 {
     "hinoko_fw_iso_resource_open";
     "hinoko_fw_iso_resource_create_source";
     "hinoko_fw_iso_resource_allocate_async";
-    "hinoko_fw_iso_resource_allocate_sync";
 
     "hinoko_fw_iso_resource_auto_get_type";
 
@@ -79,6 +78,8 @@ HINOKO_0_9_0 {
 } HINOKO_0_8_0;
 
 HINOKO_1_0_0 {
+    "hinoko_fw_iso_resource_allocate_wait";
+
     "hinoko_fw_iso_resource_once_deallocate";
     "hinoko_fw_iso_resource_once_deallocate_wait";
 

--- a/src/hinoko.map
+++ b/src/hinoko.map
@@ -50,8 +50,6 @@ HINOKO_0_7_0 {
 
     "hinoko_fw_iso_resource_once_get_type";
     "hinoko_fw_iso_resource_once_new";
-    "hinoko_fw_iso_resource_once_deallocate_async";
-    "hinoko_fw_iso_resource_once_deallocate_sync";
 } HINOKO_0_5_0;
 
 HINOKO_0_8_0 {
@@ -81,3 +79,8 @@ HINOKO_0_8_0 {
 HINOKO_0_9_0 {
     "hinoko_fw_iso_ctx_read_cycle_time";
 } HINOKO_0_8_0;
+
+HINOKO_1_0_0 {
+    "hinoko_fw_iso_resource_once_deallocate";
+    "hinoko_fw_iso_resource_once_deallocate_wait";
+} HINOKO_0_9_0;

--- a/tests/fw-iso-resource
+++ b/tests/fw-iso-resource
@@ -16,12 +16,12 @@ props = (
 methods = (
     'open',
     'create_source',
-    'allocate_async',
+    'allocate',
     'allocate_wait',
 )
 vmethods = (
     'do_open',
-    'do_allocate_async',
+    'do_allocate',
     'do_create_source',
     'do_allocated',
     'do_deallocated',

--- a/tests/fw-iso-resource
+++ b/tests/fw-iso-resource
@@ -17,7 +17,7 @@ methods = (
     'open',
     'create_source',
     'allocate_async',
-    'allocate_sync',
+    'allocate_wait',
 )
 vmethods = (
     'do_open',

--- a/tests/fw-iso-resource-auto
+++ b/tests/fw-iso-resource-auto
@@ -19,8 +19,8 @@ props = (
 )
 methods = (
     'new',
-    'deallocate_async',
-    'deallocate_sync',
+    'deallocate',
+    'deallocate_wait',
     # From interface.
     'open',
     'create_source',

--- a/tests/fw-iso-resource-auto
+++ b/tests/fw-iso-resource-auto
@@ -25,7 +25,7 @@ methods = (
     'open',
     'create_source',
     'allocate_async',
-    'allocate_sync',
+    'allocate_wait',
 )
 vmethods = (
     # From interface.

--- a/tests/fw-iso-resource-auto
+++ b/tests/fw-iso-resource-auto
@@ -24,13 +24,13 @@ methods = (
     # From interface.
     'open',
     'create_source',
-    'allocate_async',
+    'allocate',
     'allocate_wait',
 )
 vmethods = (
     # From interface.
     'do_open',
-    'do_allocate_async',
+    'do_allocate',
     'do_create_source',
     'do_allocated',
     'do_deallocated',

--- a/tests/fw-iso-resource-once
+++ b/tests/fw-iso-resource-once
@@ -21,11 +21,14 @@ methods = (
     # From interface.
     'open',
     'create_source',
-    'allocate_async',
+    'allocate',
     'allocate_wait',
 )
 vmethods = (
     # From interface.
+    'do_open',
+    'do_allocate',
+    'do_create_source',
     'do_allocated',
     'do_deallocated',
 )

--- a/tests/fw-iso-resource-once
+++ b/tests/fw-iso-resource-once
@@ -16,8 +16,8 @@ props = (
 )
 methods = (
     'new',
-    'deallocate_async',
-    'deallocate_sync',
+    'deallocate',
+    'deallocate_wait',
     # From interface.
     'open',
     'create_source',

--- a/tests/fw-iso-resource-once
+++ b/tests/fw-iso-resource-once
@@ -22,7 +22,7 @@ methods = (
     'open',
     'create_source',
     'allocate_async',
-    'allocate_sync',
+    'allocate_wait',
 )
 vmethods = (
     # From interface.


### PR DESCRIPTION
The request of allocation/deallocation generates completion event. In current implementation, the method for request has async suffix, and the method to wait for the event has sync suffix. However, these two keywords are often heavy use in different contexts and sometimes unfriendly to developers and users.

The series of patches removes these contested suffixes from these methods.

```
Takashi Sakamoto (4):
  fw_iso_resource_once: remove async/sync suffixes from deallocation
    methods
  fw_iso_resource_auto: remove async/sync suffixes from deallocation
    methods
  fw_iso_resource: remove sync suffix from allocate methods
  fw_iso_resource: remove async suffix from allocation methods

 samples/iso-resource       |  8 ++++----
 src/fw_iso_resource.c      | 28 ++++++++++++++--------------
 src/fw_iso_resource.h      | 18 +++++++++---------
 src/fw_iso_resource_auto.c | 26 ++++++++++++--------------
 src/fw_iso_resource_auto.h |  5 ++---
 src/fw_iso_resource_once.c | 26 +++++++++++++-------------
 src/fw_iso_resource_once.h |  6 +++---
 src/hinoko.map             | 17 +++++++++++------
 tests/fw-iso-resource      |  6 +++---
 tests/fw-iso-resource-auto | 10 +++++-----
 tests/fw-iso-resource-once | 11 +++++++----
 11 files changed, 83 insertions(+), 78 deletions(-)
```