### PR TITLE
samples: add Python 3 asynchronous runtime sample

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,21 +16,9 @@ jobs:
         dnf -y install gi-docgen python3-gobject
     - name: Checkout repository.
       uses: actions/checkout@v4
-    - name: Create gi-docgen.wrap in subproject directory
-      run: |
-        mkdir subprojects
-        cat > subprojects/gi-docgen.wrap << EOF
-        [wrap-git]
-        directory = gi-docgen
-        url = https://gitlab.gnome.org/GNOME/gi-docgen.git
-        revision = 2023.1
-        depth = 1
-        
-        [provide]
-        program_names = gi-docgen
-        EOF
     - name: Create hinawa.wrap in subproject directory
       run: |
+        mkdir subprojects
         cat > subprojects/hinawa.wrap << EOF
         [wrap-git]
         directory = libhinawa
@@ -71,21 +59,9 @@ jobs:
         DEBIAN_FRONTEND=noninteractive apt-get install -y gi-docgen python3-gi
     - name: Checkout repository.
       uses: actions/checkout@v4
-    - name: Create gi-docgen.wrap in subproject directory
-      run: |
-        mkdir subprojects
-        cat > subprojects/gi-docgen.wrap << EOF
-        [wrap-git]
-        directory = gi-docgen
-        url = https://gitlab.gnome.org/GNOME/gi-docgen.git
-        revision = 2023.1
-        depth = 1
-        
-        [provide]
-        program_names = gi-docgen
-        EOF
     - name: Create hinawa.wrap in subproject directory
       run: |
+        mkdir subprojects
         cat > subprojects/hinawa.wrap << EOF
         [wrap-git]
         directory = libhinawa

--- a/samples/iso-resource
+++ b/samples/iso-resource
@@ -1,104 +1,163 @@
 #!/usr/bin/env python3
 
-import gi
-gi.require_versions({'GLib': '2.0', 'Hinoko': '1.0'})
-from gi.repository import GLib, Hinoko
+from pathlib import Path
+from sys import argv, exit
+import traceback
 
 from threading import Thread
-from time import sleep
+from contextlib import AbstractContextManager, contextmanager
 
-bytes_per_payload = (2 + 8 * 3) * 4
-use_channel = 10
-use_bandwidth = Hinoko.FwIsoResource.calculate_bandwidth(bytes_per_payload,
-                                                         Hinoko.FwScode.S400)
+import gi
 
-ctx = GLib.MainContext.new()
-dispatcher = GLib.MainLoop.new(ctx, False)
-th = Thread(target=lambda d: d.run(), args=(dispatcher,))
-th.start()
+gi.require_versions({"GLib": "2.0", "Hinoko": "1.0"})
+from gi.repository import GLib, Hinoko
 
-def handle_event(res, channel, bandwidth, exception, ev_name):
-    print('event:', ev_name)
-    if exception is None:
-        print('  ', channel, bandwidth, res.get_property('generation'))
-    elif exception.matches(Hinoko.fw_iso_resource_error_quark(), Hinoko.FwIsoResourceError.EVENT):
-        print('  ', exception)
+BYTES_PER_PAYLOAD = (2 + 8 * 3) * 4
+USE_CHANNEL = 10
+USE_BANDWIDTH = Hinoko.FwIsoResource.calculate_bandwidth(
+    BYTES_PER_PAYLOAD, Hinoko.FwScode.S400
+)
+TIMEOUT_MS = 100
 
-# For Once mode. The allocation is bound to current generation of the bus and
-# lost automatically by bus reset without notification.
-res = Hinoko.FwIsoResourceOnce.new()
-res.open('/dev/fw0', 0)
-res.connect('allocated', handle_event, 'allocated')
-res.connect('deallocated', handle_event, 'deallocated')
 
-_, src = res.create_source()
-src.attach(ctx)
+# Just for printing events, no functional purpose.
+def handle_resource_signal(
+    res: Hinoko.FwIsoResource,
+    channel: int,
+    bandwidth: int,
+    error: GLib.Error,
+    label: str,
+):
+    print("event:", label)
+    if error is None:
+        print("  ", channel, bandwidth, res.get_property("generation"))
+    elif error.matches(
+        Hinoko.fw_iso_resource_error_quark(), Hinoko.FwIsoResourceError.EVENT
+    ):
+        print("  ", error)
 
-for i in range(2):
-    try:
-        res.allocate_wait((use_channel, ), use_bandwidth, 100)
-    except GLib.Error as e:
-        if e.matches(Hinoko.fw_iso_resource_error_quark(), Hinoko.FwIsoResourceError.EVENT):
-            print(e)
-    else:
-        print('result: allocate')
-        print('  ', use_channel, use_bandwidth, res.get_property('generation'))
 
-    sleep(2)
+# For Once mode. The allocation is bound to current generation of the bus and lost automatically by
+# bus reset without notification.
+def main_once(res: Hinoko.FwIsoResourceAuto, ctx: GLib.MainContext):
+    _, src = res.create_source()
+    _ = src.attach(ctx)
 
-    try:
-        res.deallocate_wait(use_channel, use_bandwidth, 100)
-    except GLib.Error as e:
-        if e.matches(Hinoko.fw_iso_resource_error_quark(), Hinoko.FwIsoResourceError.EVENT):
-            print(e)
-    else:
-        print('result: deallocate')
-        print('  ', use_channel, use_bandwidth, res.get_property('generation'))
+    handler_id_allocated = res.connect("allocated", handle_resource_signal, "allocated")
+    handler_id_deallocated = res.connect(
+        "deallocated", handle_resource_signal, "deallocated"
+    )
 
-    sleep(2)
+    for i in range(2):
+        res.allocate_wait((USE_CHANNEL,), USE_BANDWIDTH, TIMEOUT_MS)
+        print("result: allocate")
+        print("  ", USE_CHANNEL, USE_BANDWIDTH, res.get_property("generation"))
 
-src.destroy()
-del res
+        res.deallocate_wait(USE_CHANNEL, USE_BANDWIDTH, TIMEOUT_MS)
+        print("result: deallocate")
+        print("  ", USE_CHANNEL, USE_BANDWIDTH, res.get_property("generation"))
 
-# For Auto mode. The allocation is kept by Linux FireWire subsystem as long as
-# the lifetime of file descriptor. The instance of object represents state
-# machine.
-res = Hinoko.FwIsoResourceAuto.new()
-res.open('/dev/fw0', 0)
-res.connect('allocated', handle_event, 'allocated')
-res.connect('deallocated', handle_event, 'deallocated')
+    res.disconnect(handler_id_deallocated)
+    res.disconnect(handler_id_allocated)
+    src.destroy()
 
-_, src = res.create_source()
-src.attach(ctx)
 
-def print_props(res):
-    for prop in ('is-allocated', 'channel', 'bandwidth', 'generation'):
-        print('  {}: {}'.format(prop, res.get_property(prop)))
+# For Auto mode. The allocation is kept by Linux FireWire subsystem as long as the lifetime of
+# file descriptor. The instance of object represents state machine.
+def main_auto(res: Hinoko.FwIsoResourceAuto, ctx: GLib.MainContext):
+    def print_props(res):
+        for prop in ("is-allocated", "channel", "bandwidth", "generation"):
+            print("  {}: {}".format(prop, res.get_property(prop)))
 
-for i in range(2):
+    _, src = res.create_source()
+    _ = src.attach(ctx)
+
+    handler_id_allocated = res.connect("allocated", handle_resource_signal, "allocated")
+    handler_id_deallocated = res.connect(
+        "deallocated", handle_resource_signal, "deallocated"
+    )
+
     print_props(res)
 
-    try:
-        res.allocate_wait([use_channel], use_bandwidth, 100)
-    except GLib.Error as e:
-        if e.matches(Hinoko.fw_iso_resource_error_quark(), Hinoko.FwIsoResourceError.EVENT):
-            print(e)
-    else:
-        print('result: allocate')
+    for i in range(2):
+        res.allocate_wait([USE_CHANNEL], USE_BANDWIDTH, TIMEOUT_MS)
+        print("result: allocate")
         print_props(res)
 
-    sleep(1)
-
-    try:
-        res.deallocate_wait(100)
-    except GLib.Error as e:
-        if e.matches(Hinoko.fw_iso_resource_error_quark(), Hinoko.FwIsoResourceError.EVENT):
-            print(e)
-    else:
-        print('result: deallocate')
+        res.deallocate_wait(TIMEOUT_MS)
+        print("result: deallocate")
         print_props(res)
 
-    sleep(1)
+    res.disconnect(handler_id_deallocated)
+    res.disconnect(handler_id_allocated)
+    src.destroy()
 
-dispatcher.quit()
-th.join()
+
+@contextmanager
+def run_dispatcher() -> AbstractContextManager[GLib.MainContext]:
+    ctx = GLib.MainContext.new()
+    dispatcher = GLib.MainLoop.new(ctx, False)
+
+    th = Thread(target=lambda d: d.run(), args=(dispatcher,))
+    th.start()
+
+    try:
+        yield ctx
+    finally:
+        dispatcher.quit()
+        th.join()
+
+
+def multithread_main(path: Path) -> int:
+    res_once = Hinoko.FwIsoResourceOnce.new()
+    res_once.open(str(path), 0)
+
+    res_auto = Hinoko.FwIsoResourceAuto.new()
+    res_auto.open(str(path), 0)
+
+    try:
+        with run_dispatcher() as ctx:
+            main_once(res_once, ctx)
+            main_auto(res_auto, ctx)
+    except GLib.Error as e:
+        error_domain_map = {
+            GLib.file_error_quark(): GLib.FileError,
+            Hinoko.fw_iso_resource_error_quark(): Hinoko.FwIsoResourceError,
+            Hinoko.fw_iso_resource_auto_error_quark(): Hinoko.FwIsoResourceAutoError,
+        }
+        quark = GLib.quark_from_string(e.domain)
+        if quark in error_domain_map:
+            code_nick = error_domain_map[quark](e.code).value_nick
+            print(
+                "GLib.Error exception: '{}' due to '{}' in '{}'".format(
+                    e.message, code_nick, e.domain
+                )
+            )
+            print()
+        traceback.print_exception(e)
+        return 1
+    except Exception as e:
+        traceback.print_exception(e)
+        return 1
+
+    return 0
+
+
+def main() -> int:
+    if len(argv) < 2:
+        print(
+            "One argument is required for path to special file of Linux FireWire character "
+            "device"
+        )
+        return 1
+
+    path = Path(argv[1])
+    if not path.exists() or not path.is_char_device() or path.name.find("fw") != 0:
+        print("{} is invalid for Linux FireWire character device".format(path))
+        return 1
+
+    return multithread_main(path)
+
+
+if __name__ == "__main__":
+    exit(main())

--- a/samples/iso-resource-async
+++ b/samples/iso-resource-async
@@ -1,0 +1,252 @@
+#!/usr/bin/env python3
+
+from pathlib import Path
+from sys import argv, exit
+import traceback
+
+from asyncio import Event, Future, get_running_loop, run, timeout_at
+from contextlib import AbstractAsyncContextManager, asynccontextmanager
+
+import gi
+
+gi.require_versions({"GLib": "2.0", "Hinoko": "1.0"})
+from gi.repository import GLib, Hinoko
+
+BYTES_PER_PAYLOAD = (2 + 8 * 3) * 4
+USE_CHANNEL = 10
+USE_BANDWIDTH = Hinoko.FwIsoResource.calculate_bandwidth(
+    BYTES_PER_PAYLOAD, Hinoko.FwScode.S400
+)
+TIMEOUT_MS = 100
+
+
+class ResourceData:
+    def __init__(self):
+        self.channel = -1
+        self.bandwidth = -1
+
+
+def handle_resource_signal(
+    res: Hinoko.FwIsoResource,
+    channel: int,
+    bandwidth: int,
+    error: GLib.Error,
+    args: (ResourceData, Future, str),
+):
+    data, future, label = args
+
+    print("event:", label)
+    if error is None:
+        print("  ", channel, bandwidth, res.get_property("generation"))
+    elif error.matches(
+        Hinoko.fw_iso_resource_error_quark(), Hinoko.FwIsoResourceError.EVENT
+    ):
+        print("  ", error)
+
+    if error is not None:
+        future.set_exception(error)
+    else:
+        data.channel = channel
+        data.bandwidth = bandwidth
+        future.set_result("finished")
+
+
+def create_timeout_error() -> GLib.Error:
+    return GLib.Error.new_literal(
+        Hinoko.fw_iso_resource_error_quark(),
+        "timeout",
+        Hinoko.FwIsoResourceError.TIMEOUT,
+    )
+
+
+# The variation of Hinoko.FwIsoResource.allocate_wait() for asynchronous runtime.
+async def allocate_wait_async(
+    res: Hinoko.FwIsoResource, channels: tuple[int], bandwidth: int, timeout_ms: int
+) -> bool:
+    future = get_running_loop().create_future()
+    data = ResourceData()
+    handler_id = res.connect(
+        "allocated", handle_resource_signal, (data, future, "allocated")
+    )
+
+    when = get_running_loop().time() + timeout_ms / 1000.0
+    res.allocate(channels, bandwidth)
+
+    try:
+        async with timeout_at(when):
+            _ = await future
+    except TimeoutError:
+        raise create_timeout_error() from None
+    finally:
+        res.disconnect(handler_id)
+
+    return True
+
+
+# The variation of Hinoko.FwIsoResourceOnce.deallocate_wait() for asynchronous runtime.
+async def once_deallocate_wait_async(
+    res: Hinoko.FwIsoResourceOnce, channel: int, bandwidth: int, timeout_ms: int
+) -> bool:
+    future = get_running_loop().create_future()
+    data = ResourceData()
+    handler_id = res.connect(
+        "deallocated", handle_resource_signal, (data, future, "deallocated")
+    )
+
+    when = get_running_loop().time() + timeout_ms / 1000.0
+    res.deallocate(channel, bandwidth)
+
+    try:
+        async with timeout_at(when):
+            _ = await future
+    except TimeoutError:
+        raise create_timeout_error() from None
+    finally:
+        res.disconnect(handler_id)
+
+    return True
+
+
+# The variation of Hinoko.FwIsoResourceAuto.deallocate_wait() for asynchronous runtime.
+async def auto_deallocate_wait_async(
+    res: Hinoko.FwIsoResourceAuto, timeout_ms: int
+) -> bool:
+    future = get_running_loop().create_future()
+    data = ResourceData()
+    handler_id = res.connect(
+        "deallocated", handle_resource_signal, (data, future, "deallocated")
+    )
+
+    when = get_running_loop().time() + timeout_ms / 1000.0
+    res.deallocate()
+
+    try:
+        async with timeout_at(when):
+            _ = await future
+    except TimeoutError:
+        raise create_timeout_error() from None
+    finally:
+        res.disconnect(handler_id)
+
+    return True
+
+
+# For Once mode. The allocation is bound to current generation of the bus and lost automatically by
+# bus reset without notification.
+async def async_main_once(res: Hinoko.FwIsoResourceOnce, ctx: GLib.MainContext):
+    _, src = res.create_source()
+    _ = src.attach(ctx)
+
+    for _i in range(2):
+        await allocate_wait_async(res, (USE_CHANNEL,), USE_BANDWIDTH, TIMEOUT_MS)
+        print("result: allocate")
+        print("  ", USE_CHANNEL, USE_BANDWIDTH, res.get_property("generation"))
+
+        await once_deallocate_wait_async(res, USE_CHANNEL, USE_BANDWIDTH, TIMEOUT_MS)
+        print("result: deallocate")
+        print("  ", USE_CHANNEL, USE_BANDWIDTH, res.get_property("generation"))
+
+    src.destroy()
+
+
+# For Auto mode. The allocation is kept by Linux FireWire subsystem as long as the lifetime of
+# file descriptor. The instance of object represents state machine.
+async def async_main_auto(res: Hinoko.FwIsoResourceAuto, ctx: GLib.MainContext):
+    def print_props(res: Hinoko.FwIsoResourceAuto):
+        for prop in ("is-allocated", "channel", "bandwidth", "generation"):
+            print("  {}: {}".format(prop, res.get_property(prop)))
+
+    _, src = res.create_source()
+    _ = src.attach(ctx)
+
+    print_props(res)
+
+    for _i in range(2):
+        await allocate_wait_async(res, (USE_CHANNEL,), USE_BANDWIDTH, TIMEOUT_MS)
+        print("result: allocate")
+        print_props(res)
+
+        await auto_deallocate_wait_async(res, TIMEOUT_MS)
+        print("result: deallocate")
+        print_props(res)
+
+    src.destroy()
+
+
+@asynccontextmanager
+async def run_dispatcher_async() -> AbstractAsyncContextManager[GLib.MainContext]:
+    def dispatch_event(ctx: GLib.MainContext, state: Event):
+        if state.is_set():
+            ctx.iteration(False)
+            # Reschedule this immediately.
+            get_running_loop().call_later(0.0, dispatch_event, ctx, state)
+
+    ctx = GLib.MainContext.new()
+
+    ctx.acquire()
+
+    state = Event()
+    state.set()
+
+    get_running_loop().call_soon(dispatch_event, ctx, state)
+
+    try:
+        yield ctx
+    finally:
+        state.clear()
+        ctx.release()
+
+
+async def async_main(path: Path) -> int:
+    res_once = Hinoko.FwIsoResourceOnce.new()
+    res_once.open(str(path), 0)
+
+    res_auto = Hinoko.FwIsoResourceAuto.new()
+    res_auto.open(str(path), 0)
+
+    try:
+        async with run_dispatcher_async() as ctx:
+            await async_main_once(res_once, ctx)
+            await async_main_auto(res_auto, ctx)
+    except GLib.Error as e:
+        error_domain_map = {
+            GLib.file_error_quark(): GLib.FileError,
+            Hinoko.fw_iso_resource_error_quark(): Hinoko.FwIsoResourceError,
+            Hinoko.fw_iso_resource_auto_error_quark(): Hinoko.FwIsoResourceAutoError,
+        }
+        quark = GLib.quark_from_string(e.domain)
+        if quark in error_domain_map:
+            code_nick = error_domain_map[quark](e.code).value_nick
+            print(
+                "GLib.Error exception: '{}' due to '{}' in '{}'".format(
+                    e.message, code_nick, e.domain
+                )
+            )
+            print()
+        traceback.print_exception(e)
+        return 1
+    except Exception as e:
+        traceback.print_exception(e)
+        return 1
+
+    return 0
+
+
+def main() -> int:
+    if len(argv) < 2:
+        print(
+            "One argument is required for path to special file of Linux FireWire character "
+            "device"
+        )
+        return 1
+
+    path = Path(argv[1])
+    if not path.exists() or not path.is_char_device() or path.name.find("fw") != 0:
+        print("{} is invalid for Linux FireWire character device".format(path))
+        return 1
+
+    return run(async_main(path))
+
+
+if __name__ == "__main__":
+    exit(main())


### PR DESCRIPTION
Hi,

In recent years, asynchronous programming model becomes major in some languages. This series of changes adds a sample script for Python 3 asynchronous runtime.

```
Takashi Sakamoto (3):
  samples: add a Python 3 script to allocate/deallocate isochronous
    resources with asynchronous runtime
  samples: clean up a sample to allocate/deallocate isochronous
    resources by blocking API
  ci: delete gi-docgen package in each repository

 .github/workflows/build.yml |  28 +---
 samples/iso-resource        | 233 +++++++++++++++++++------------
 samples/iso-resource-async  | 264 ++++++++++++++++++++++++++++++++++++
 3 files changed, 413 insertions(+), 112 deletions(-)
 create mode 100755 samples/iso-resource-async
```